### PR TITLE
fix pom.xml for latest spark 2.4.0 in databricks

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.7</slf4j.version>
-        <spark.version>2.3.1</spark.version>
+        <spark.version>2.4.0</spark.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
this is fix to run spark monitoring on latest of spark 2.4.0. 2.3.1 was depecrated. Yammer pinged as well with the same request.