### PR TITLE
Adding custom properties for log4j appender

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.7</slf4j.version>
-        <spark.version>2.3.1</spark.version>
+        <spark.version>2.4.0</spark.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/LogAnalyticsEnvironment.java
+++ b/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/LogAnalyticsEnvironment.java
@@ -1,14 +1,30 @@
 package com.microsoft.pnp;
-
+import org.apache.commons.lang3.StringUtils;
 public class LogAnalyticsEnvironment {
     public static final String LOG_ANALYTICS_WORKSPACE_ID = "LOG_ANALYTICS_WORKSPACE_ID";
     public static final String LOG_ANALYTICS_WORKSPACE_KEY = "LOG_ANALYTICS_WORKSPACE_KEY";
+    public static final String SOURCE_CLUSTER_ID = "SOURCE_CLUSTER_ID";
+    public static final String IS_SPARK_DRIVER_NODE = "IS_SPARK_DRIVER_NODE";
+    public static final String LOG4J_TABLE_NAME = "LOG4J_TABLE_NAME";
+    private static final String DEFAULT_LOG_TYPE = "SparkLoggingEvent";
 
     public static String getWorkspaceId() {
         return System.getenv(LOG_ANALYTICS_WORKSPACE_ID);
     }
-
     public static String getWorkspaceKey() {
         return System.getenv(LOG_ANALYTICS_WORKSPACE_KEY);
     }
-}
+
+    // Get cluster ID and whether Driver node or not from environment variables in init script
+    public static String getClusterId() {
+        return System.getenv(SOURCE_CLUSTER_ID);
+    }
+    public static String isDriverNode() { return System.getenv(IS_SPARK_DRIVER_NODE); }
+    public static String getLog4jTableName() {
+        String log4jTableName =  System.getenv(LOG4J_TABLE_NAME);
+        if (!StringUtils.isEmpty(log4jTableName))
+             return System.getenv(LOG4J_TABLE_NAME);
+        else
+             return DEFAULT_LOG_TYPE;
+    }
+  }

--- a/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/listeners/sink/loganalytics/LogAnalyticsListenerSinkConfiguration.scala
+++ b/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/listeners/sink/loganalytics/LogAnalyticsListenerSinkConfiguration.scala
@@ -7,8 +7,7 @@ private[spark] object LogAnalyticsListenerSinkConfiguration {
   private val CONFIG_PREFIX = "spark.logAnalytics"
 
   private[spark] val WORKSPACE_ID = CONFIG_PREFIX + ".workspaceId"
-
-  // We'll name this secret so Spark will redact it.
+   // We'll name this secret so Spark will redact it.
   private[spark] val SECRET = CONFIG_PREFIX + ".secret"
 
   private[spark] val LOG_TYPE = CONFIG_PREFIX + ".logType"

--- a/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/metrics/sink/loganalytics/LogAnalyticsMetricsSink.scala
+++ b/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/metrics/sink/loganalytics/LogAnalyticsMetricsSink.scala
@@ -32,7 +32,7 @@ private class LogAnalyticsMetricsSink(
   override def stop(): Unit = {
     reporter.stop()
     logInfo("LogAnalyticsMetricsSink stopped.")
-  }
+    }
 
   override def report(): Unit = {
     reporter.report()


### PR DESCRIPTION
Added clusterID and isDriverNode properties to log4j appender so that on the query side you can filter logs by cluster and aggregate by cluster otherwise if logging multiple clusters in same log analytics workspace, there is no way to filter out logs.
Also added option to change the default table name via environment variable for the log appender only.