### PR TITLE
Support for Databricks v6.4 runtime with new maven profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ databricks runtime.
 | -- | -- |
 | `5.5`, `6.0` | `scala-2.11_spark-2.4.3` |
 | `6.1` - `6.3` | `scala-2.11_spark-2.4.4` |
+| `6.4` | `scala-2.11_spark-2.4.5` |
 
 1. Use Maven to build the POM located at `sample/spark-sample-job/pom.xml` or run the following Docker command:
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 echo 'hosts: files dns' > /etc/nsswitch.conf
 echo "127.0.0.1   $(hostname)" >> /etc/hosts
 
-MAVEN_PROFILES=( "scala-2.11_spark-2.4.0" "scala-2.11_spark-2.4.1" "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.4" )
+MAVEN_PROFILES=( "scala-2.11_spark-2.4.0" "scala-2.11_spark-2.4.1" "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.4" "scala-2.11_spark-2.4.5" )
 for MAVEN_PROFILE in "${MAVEN_PROFILES[@]}"
 do
     mvn -f /spark-monitoring/src/pom.xml install -P ${MAVEN_PROFILE}

--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -55,7 +55,22 @@
             </properties>
         </profile>
         <profile>
-            <id>scala-2.11_spark-2.4.4</id>
+            <id>scala-2.11_spark-2.4.4</id>            
+            <properties>
+                <codahale.metrics.version>3.1.5</codahale.metrics.version>
+                <commons-codec.version>1.10</commons-codec.version>
+                <commons.httpclient.version>4.5.6</commons.httpclient.version>
+                <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
+                <jetty.version>9.3.27.v20190418</jetty.version>
+                <log4j.version>1.2.17</log4j.version>
+                <slf4j.version>1.7.16</slf4j.version>
+                <spark.version>2.4.4</spark.version>
+                <scala.version>2.11.12</scala.version>
+                <scala.compat.version>2.11</scala.compat.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.11_spark-2.4.5</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -67,7 +82,7 @@
                 <jetty.version>9.3.27.v20190418</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
-                <spark.version>2.4.4</spark.version>
+                <spark.version>2.4.5</spark.version>
                 <scala.version>2.11.12</scala.version>
                 <scala.compat.version>2.11</scala.compat.version>
             </properties>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -60,7 +60,22 @@
             </properties>
         </profile>
         <profile>
-            <id>scala-2.11_spark-2.4.4</id>
+            <id>scala-2.11_spark-2.4.4</id>            
+            <properties>
+                <codahale.metrics.version>3.1.5</codahale.metrics.version>
+                <commons-codec.version>1.10</commons-codec.version>
+                <commons.httpclient.version>4.5.6</commons.httpclient.version>
+                <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
+                <jetty.version>9.3.27.v20190418</jetty.version>
+                <log4j.version>1.2.17</log4j.version>
+                <slf4j.version>1.7.16</slf4j.version>
+                <spark.version>2.4.4</spark.version>
+                <scala.version>2.11.12</scala.version>
+                <scala.compat.version>2.11</scala.compat.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.11_spark-2.4.5</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -72,7 +87,7 @@
                 <jetty.version>9.3.27.v20190418</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
-                <spark.version>2.4.4</spark.version>
+                <spark.version>2.4.5</spark.version>
                 <scala.version>2.11.12</scala.version>
                 <scala.compat.version>2.11</scala.compat.version>
             </properties>


### PR DESCRIPTION
- Added new maven profile 'scala-2.11_spark-2.4.5' that uses spark v2.4.5 and is targeting Databricks runtime v.6.4
- Profile added to both spark-monitoring library and sample
- Updated build.sh to include new maven profile
- Updated readme to include new maven profile

Fixes #76 