### PR TITLE
Update jetty-server version to 9.4.31.v20200723

### DIFF
--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -16,7 +16,7 @@
                 <commons-codec.version>1.10</commons-codec.version>
                 <commons.httpclient.version>4.5.4</commons.httpclient.version>
                 <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
                 <spark.version>2.4.0</spark.version>
@@ -31,7 +31,7 @@
                 <commons-codec.version>1.10</commons-codec.version>
                 <commons.httpclient.version>4.5.4</commons.httpclient.version>
                 <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
                 <spark.version>2.4.1</spark.version>
@@ -46,7 +46,7 @@
                 <commons-codec.version>1.10</commons-codec.version>
                 <commons.httpclient.version>4.5.4</commons.httpclient.version>
                 <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
                 <spark.version>2.4.3</spark.version>
@@ -61,7 +61,7 @@
                 <commons-codec.version>1.10</commons-codec.version>
                 <commons.httpclient.version>4.5.6</commons.httpclient.version>
                 <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
-                <jetty.version>9.3.27.v20190418</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
                 <spark.version>2.4.4</spark.version>
@@ -79,7 +79,7 @@
                 <commons-codec.version>1.10</commons-codec.version>
                 <commons.httpclient.version>4.5.6</commons.httpclient.version>
                 <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
-                <jetty.version>9.3.27.v20190418</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
                 <spark.version>2.4.5</spark.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -18,7 +18,7 @@
             <id>scala-2.11_spark-2.4.0</id>
             <properties>
                 <commons.httpclient.version>4.5.4</commons.httpclient.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <spark.version>2.4.0</spark.version>
                 <scala.version>2.11.8</scala.version>
                 <scala.compat.version>2.11</scala.compat.version>
@@ -28,7 +28,7 @@
             <id>scala-2.11_spark-2.4.1</id>
             <properties>
                 <commons.httpclient.version>4.5.4</commons.httpclient.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <spark.version>2.4.1</spark.version>
                 <scala.version>2.11.8</scala.version>
                 <scala.compat.version>2.11</scala.compat.version>
@@ -38,7 +38,7 @@
             <id>scala-2.11_spark-2.4.3</id>
             <properties>
                 <commons.httpclient.version>4.5.4</commons.httpclient.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <spark.version>2.4.3</spark.version>
                 <scala.version>2.11.8</scala.version>
                 <scala.compat.version>2.11</scala.compat.version>
@@ -51,7 +51,7 @@
                 <commons-codec.version>1.10</commons-codec.version>
                 <commons.httpclient.version>4.5.6</commons.httpclient.version>
                 <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
-                <jetty.version>9.3.27.v20190418</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
                 <spark.version>2.4.4</spark.version>
@@ -69,7 +69,7 @@
                 <commons-codec.version>1.10</commons-codec.version>
                 <commons.httpclient.version>4.5.6</commons.httpclient.version>
                 <fasterxml.jackson.databind.version>2.6.7.1</fasterxml.jackson.databind.version>
-                <jetty.version>9.3.27.v20190418</jetty.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
                 <log4j.version>1.2.17</log4j.version>
                 <slf4j.version>1.7.16</slf4j.version>
                 <spark.version>2.4.5</spark.version>


### PR DESCRIPTION
Testing done:
Built package with
mvn package -P "scala-2.11_spark-2.4.4"
mvn package -P "scala-2.11_spark-2.4.5"

Tested on Azure Databricks 6.6 (Apache Spark 2.4.5, Scala 2.11)

Confirmed logging is landing in Log Analytics workspace for
SparkMetric_CL, SparkListenerEvent_CL, and SparkLoggingEvent_CL.