### PR TITLE
Fix scala version detection

### DIFF
--- a/src/spark-listeners/scripts/spark-monitoring.sh
+++ b/src/spark-listeners/scripts/spark-monitoring.sh
@@ -32,8 +32,7 @@ SPARK_LISTENERS_VERSION=${SPARK_LISTENERS_VERSION:-1.0.0}
 SPARK_LISTENERS_LOG_ANALYTICS_VERSION=${SPARK_LISTENERS_LOG_ANALYTICS_VERSION:-1.0.0}
 SPARK_VERSION=$(cat /databricks/spark/VERSION 2> /dev/null || echo "")
 SPARK_VERSION=${SPARK_VERSION:-2.4.3}
-SPARK_SCALA_VERSION=$(sed -n "s/\s*spark.databricks.clusterUsageTags.sparkVersion\s*=\s*\"\([^\"]*\)\"/\1/p" /databricks/common/conf/deploy.conf | \
-sed -n "s/.*scala\(.*\)/\1/p")
+SPARK_SCALA_VERSION=$(ls /databricks/spark/assembly/target | cut -d '-' -f2 2> /dev/null || echo "")
 SPARK_SCALA_VERSION=${SPARK_SCALA_VERSION:-2.11}
 
 # This variable configures the spark-monitoring library metrics sink.


### PR DESCRIPTION
Use of a different file to detect the used scala version on a Databricks Cluster. Should fix #103.