### PR TITLE
adding compatibility to Spark 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ databricks runtime.
 | `5.5` | `scala-2.11_spark-2.4.3` |
 | `6.4` - `6.6` | `scala-2.11_spark-2.4.5` |
 | `7.0` - `7.2` | `scala-2.12_spark-3.0.0` |
-| `7.3` | `scala-2.12_spark-3.0.1` |
+| `7.3` - `7.4` | `scala-2.12_spark-3.0.1` |
 
 1. Use Maven to build the POM located at `sample/spark-sample-job/pom.xml` or run the following Docker command:
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ databricks runtime.
 | -- | -- |
 | `5.5` | `scala-2.11_spark-2.4.3` |
 | `6.4` - `6.6` | `scala-2.11_spark-2.4.5` |
+| `7.0` - `7.2` | `scala-2.12_spark-3.0.0` |
+| `7.3` | `scala-2.12_spark-3.0.1` |
 
 1. Use Maven to build the POM located at `sample/spark-sample-job/pom.xml` or run the following Docker command:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker run -it --rm -v %cd%/spark-monitoring:/spark-monitoring -v "%USERPROFILE%
     * spark-listeners
     * spark-listeners-loganalytics
 
-1. Activate a **single** Maven profile that corresponds to the versions of the Scala/Spark combination that is being used. By default, the Scala 2.11 and Spark 2.4.3 profile is active.
+1. Activate a **single** Maven profile that corresponds to the versions of the Scala/Spark combination that is being used. By default, the Scala 2.12 and Spark 3.0.1 profile is active.
 
 1. Execute the Maven **package** phase in your Java IDE to build the JAR files for each of the these projects:
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 echo 'hosts: files dns' > /etc/nsswitch.conf
 echo "127.0.0.1   $(hostname)" >> /etc/hosts
 
-MAVEN_PROFILES=( "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.5" )
+MAVEN_PROFILES=( "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.5" "scala-2.12_spark-3.0.0" "scala-2.12_spark-3.0.1")
 for MAVEN_PROFILE in "${MAVEN_PROFILES[@]}"
 do
     mvn -f /spark-monitoring/src/pom.xml install -P ${MAVEN_PROFILE}

--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -32,6 +32,29 @@
                 <scala.compat.version>2.11</scala.compat.version>
             </properties>
         </profile>
+        <profile>
+            <id>scala-2.12_spark-3.0.0</id>
+            <properties>
+                <jetty.version>9.4.31.v20200723</jetty.version>
+                <slf4j.version>1.7.16</slf4j.version>
+                <spark.version>3.0.0</spark.version>
+                <scala.version>2.12.12</scala.version>
+                <scala.compat.version>2.12</scala.compat.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.12_spark-3.0.1</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <jetty.version>9.4.31.v20200723</jetty.version>
+                <slf4j.version>1.7.16</slf4j.version>
+                <spark.version>3.0.1</spark.version>
+                <scala.version>2.12.12</scala.version>
+                <scala.compat.version>2.12</scala.compat.version>
+            </properties>
+        </profile>
     </profiles>
 
     <properties>

--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -21,9 +21,6 @@
         </profile>
         <profile>
             <id>scala-2.11_spark-2.4.5</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <jetty.version>9.4.31.v20200723</jetty.version>
                 <slf4j.version>1.7.16</slf4j.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -37,6 +37,32 @@
                 <scala.compat.version>2.11</scala.compat.version>
             </properties>
         </profile>
+        <profile>
+            <id>scala-2.12_spark-3.0.0</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <commons.httpclient.version>4.5.12</commons.httpclient.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
+                <spark.version>3.0.0</spark.version>
+                <scala.version>2.12.12</scala.version>
+                <scala.compat.version>2.12</scala.compat.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.12_spark-3.0.1</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <commons.httpclient.version>4.5.12</commons.httpclient.version>
+                <jetty.version>9.4.31.v20200723</jetty.version>
+                <spark.version>3.0.1</spark.version>
+                <scala.version>2.12.12</scala.version>
+                <scala.compat.version>2.12</scala.compat.version>
+            </properties>
+        </profile>
     </profiles>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -81,15 +107,26 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-reflect</artifactId>
+                <version>${scala.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest_${scala.compat.version}</artifactId>
-                <version>3.0.3</version>
+                <version>3.0.9</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-compiler</artifactId>
+                <version>${scala.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.10.19</version>
+                <version>3.5.15</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -26,9 +26,6 @@
         </profile>
         <profile>
             <id>scala-2.11_spark-2.4.5</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <commons.httpclient.version>4.5.12</commons.httpclient.version>
                 <jetty.version>9.4.31.v20200723</jetty.version>
@@ -39,9 +36,6 @@
         </profile>
         <profile>
             <id>scala-2.12_spark-3.0.0</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <commons.httpclient.version>4.5.12</commons.httpclient.version>
                 <jetty.version>9.4.31.v20200723</jetty.version>

--- a/src/spark-listeners-loganalytics/pom.xml
+++ b/src/spark-listeners-loganalytics/pom.xml
@@ -21,6 +21,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
 
 <!--        Test Dependencies-->
         <dependency>
@@ -39,6 +44,12 @@
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/spark-listeners/pom.xml
+++ b/src/spark-listeners/pom.xml
@@ -30,8 +30,13 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
 
-<!--        Test Dependencies-->
+        <!--        Test Dependencies-->
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.compat.version}</artifactId>
@@ -51,32 +56,38 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
             <!--<plugin>-->
-                <!--<groupId>org.scalatest</groupId>-->
-                <!--<artifactId>scalatest-maven-plugin</artifactId>-->
-                <!--<version>2.0.0</version>-->
-                <!--<configuration>-->
-                    <!--<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>-->
-                    <!--<junitxml>.</junitxml>-->
-                    <!--<filereports>TestSuiteReport.txt</filereports>-->
-                    <!--<parallel>false</parallel>-->
-                    <!--<forkMode>never</forkMode>-->
-                    <!--<systemProperties>-->
-                        <!--<log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>-->
-                    <!--</systemProperties>-->
-                    <!--<skipTests>false</skipTests>-->
-                <!--</configuration>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>test</id>-->
-                        <!--<goals>-->
-                            <!--<goal>test</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
+            <!--<groupId>org.scalatest</groupId>-->
+            <!--<artifactId>scalatest-maven-plugin</artifactId>-->
+            <!--<version>2.0.0</version>-->
+            <!--<configuration>-->
+            <!--<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>-->
+            <!--<junitxml>.</junitxml>-->
+            <!--<filereports>TestSuiteReport.txt</filereports>-->
+            <!--<parallel>false</parallel>-->
+            <!--<forkMode>never</forkMode>-->
+            <!--<systemProperties>-->
+            <!--<log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>-->
+            <!--</systemProperties>-->
+            <!--<skipTests>false</skipTests>-->
+            <!--</configuration>-->
+            <!--<executions>-->
+            <!--<execution>-->
+            <!--<id>test</id>-->
+            <!--<goals>-->
+            <!--<goal>test</goal>-->
+            <!--</goals>-->
+            <!--</execution>-->
+            <!--</executions>-->
             <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/spark-listeners/src/main/scala/org/apache/spark/listeners/StreamingListenerHandlers.scala
+++ b/src/spark-listeners/src/main/scala/org/apache/spark/listeners/StreamingListenerHandlers.scala
@@ -155,9 +155,11 @@ class StreamingListenerEventWrapperTypeIdResolver extends com.fasterxml.jackson.
 
   override def idFromBaseType(): String = throw new NotImplementedError()
 
-  override def typeFromId(s: String): JavaType = throw new NotImplementedError()
+  def typeFromId(s: String): JavaType = throw new NotImplementedError()
 
   override def typeFromId(databindContext: DatabindContext, s: String): JavaType = throw new NotImplementedError()
 
   override def getMechanism: JsonTypeInfo.Id = JsonTypeInfo.Id.CUSTOM
+
+  def getDescForKnownTypeIds: String = throw new NotImplementedError()
 }

--- a/src/spark-listeners/src/test/scala/org/apache/spark/listeners/LogAnalyticsListenerSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/listeners/LogAnalyticsListenerSuite.scala
@@ -6,11 +6,13 @@ import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.storage.{BlockManagerId, BlockUpdatedInfo, RDDBlockId, StorageLevel}
 import org.apache.spark.util.{AccumulatorMetadata, LongAccumulator}
-import org.apache.spark.{SparkConf, Success, TaskState}
+import org.apache.spark.{SparkConf, TaskState}
 import org.json4s.JsonAST.JValue
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterEach, PrivateMethodTester}
+
+import org.apache.spark.metrics.TestUtils._
 
 case class TestOtherEvent(
                            val myInt: Int,
@@ -41,13 +43,32 @@ object LogAnalyticsListenerSuite {
     createTaskInfo(0, 0)
   )
 
-  val sparkListenerTaskEnd = SparkListenerTaskEnd(
-    stageId = 0,
-    stageAttemptId = 0,
-    taskType = "",
-    reason = Success,
-    createTaskInfo(0, 0),
-    null)
+  //Spark 3 requires an additional parameter. This is the best way to not duplicate code and support both.
+  val sparkListenerTaskEnd = conditionalCode(
+    """
+      | SparkListenerTaskEnd(
+      |    stageId = 0,
+      |    stageAttemptId = 0,
+      |    taskType = "",
+      |    reason = Success,
+      |    createTaskInfo(0, 0),
+      |    taskMetrics=null)
+      |""".stripMargin,
+
+    """
+      | import org.apache.spark.executor.ExecutorMetrics
+      |
+      | SparkListenerTaskEnd(
+      |    stageId = 0,
+      |    stageAttemptId = 0,
+      |    taskType = "",
+      |    reason = Success,
+      |    createTaskInfo(0, 0),
+      |    taskMetrics=null,
+      |    taskExecutorMetrics=new ExecutorMetrics())
+      |""".stripMargin
+  ).asInstanceOf[SparkListenerTaskEnd]
+
 
   val sparkListenerStageSubmitted = SparkListenerStageSubmitted(createStageInfo(0, 0))
   sparkListenerStageSubmitted.stageInfo.submissionTime = Option(ListenerSuite.EPOCH_TIME)
@@ -110,7 +131,8 @@ object LogAnalyticsListenerSuite {
       "Classpath Entries" -> Seq(
         "/jar1" -> "System",
         "/jar2" -> "User"
-      )
+      ),
+      "Hadoop Properties" -> Seq()
     )
   )
 

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/CustomMetricsSystemSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/CustomMetricsSystemSuite.scala
@@ -3,7 +3,7 @@ package org.apache.spark.metrics
 import org.apache.spark._
 import org.apache.spark.rpc.RpcEnv
 import org.mockito.AdditionalAnswers
-import org.mockito.Matchers.{any, argThat}
+import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 
@@ -33,6 +33,8 @@ class MetricsSystemsSuite extends SparkFunSuite
 
   private var env: SparkEnv = null
   private var rpcEnv: RpcEnv = null
+
+  import TestImplicits._
 
   override def beforeEach(): Unit = {
     super.beforeEach
@@ -67,7 +69,6 @@ class MetricsSystemsSuite extends SparkFunSuite
     )
 
     assert(metricsSystem !== null)
-    import TestImplicits.matcher
     verify(envMetricsSystem, times(1)).registerSource(
       argThat((source: org.apache.spark.metrics.source.Source) => source.metricRegistry.counter(
         MetricsSystemsSuite.CounterName
@@ -86,7 +87,6 @@ class MetricsSystemsSuite extends SparkFunSuite
     )
 
     assert(metricsSystem !== null)
-    import TestImplicits.matcher
     verify(envMetricsSystem, times(1)).registerSource(
       argThat((source: org.apache.spark.metrics.source.Source) => source.metricRegistry.counter(
         MetricsSystemsSuite.CounterName

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricProxiesSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricProxiesSuite.scala
@@ -25,11 +25,11 @@ object MetricProxiesSuite {
 class MetricProxiesSuite extends SparkFunSuite
   with BeforeAndAfterEach {
 
-
+  import TestImplicits._
 
   private var rpcMetricsReceiverRef: RpcEndpointRef = null
 
-  val clockClazz = loadOneOf("com.codahale.metrics.jvm.CpuTimeClock", "com.codahale.metrics.Clock.CpuTimeClock").get
+  val clockClazz = loadOneOf("com.codahale.metrics.jvm.CpuTimeClock", "com.codahale.metrics.Clock$CpuTimeClock").get
 
   override def beforeEach(): Unit = {
     super.beforeEach

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricProxiesSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricProxiesSuite.scala
@@ -5,9 +5,11 @@ import java.util.concurrent.TimeUnit
 import com.codahale.metrics.{Clock, ExponentiallyDecayingReservoir, UniformReservoir}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.rpc.RpcEndpointRef
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
+
+import scala.util.Try
 
 
 
@@ -26,6 +28,11 @@ class MetricProxiesSuite extends SparkFunSuite
   import TestImplicits._
 
   private var rpcMetricsReceiverRef: RpcEndpointRef = null
+
+  val ClockClass = Try{
+    Class.forName("com.codahale.metrics.jvm.CpuTimeClock")
+  }
+    .getOrElse(Class.forName("com.codahale.metrics.Clock.CpuTimeClock"))
 
   override def beforeEach(): Unit = {
     super.beforeEach
@@ -138,10 +145,10 @@ class MetricProxiesSuite extends SparkFunSuite
       this.rpcMetricsReceiverRef,
       MetricProxiesSuite.MetricNamespace,
       MetricProxiesSuite.HistogramName,
-      new Clock.CpuTimeClock)
+      ClockClass.newInstance().asInstanceOf[Clock])
     proxy.mark(value)
     verify(this.rpcMetricsReceiverRef).send(argThat(
-      (message: MeterMessage) => message.value === value && message.clockClass === classOf[Clock.CpuTimeClock]))
+      (message: MeterMessage) => message.value === value && message.clockClass === ClockClass))
   }
 
   test("TimerProxy calls sendMetric with a TimerMessage for update(Long, TimeUnit)") {
@@ -183,7 +190,7 @@ class MetricProxiesSuite extends SparkFunSuite
       MetricProxiesSuite.MetricNamespace,
       MetricProxiesSuite.TimerName,
       new UniformReservoir,
-      new Clock.CpuTimeClock
+      ClockClass.newInstance().asInstanceOf[Clock]
     )
 
     proxy.update(value, TimeUnit.SECONDS)
@@ -191,7 +198,7 @@ class MetricProxiesSuite extends SparkFunSuite
       (message: TimerMessage) => message.value === value &&
         message.timeUnit === TimeUnit.SECONDS &&
         message.reservoirClass === classOf[UniformReservoir] &&
-        message.clockClass === classOf[Clock.CpuTimeClock]))
+        message.clockClass === ClockClass))
   }
 
   test("SettableGaugeProxy calls sendMetric with a SettableGaugeMessage for set(Long)") {

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricsSourceBuildersSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricsSourceBuildersSuite.scala
@@ -3,7 +3,7 @@ package org.apache.spark.metrics
 import com.codahale.metrics._
 import org.apache.spark._
 import org.apache.spark.rpc.{RpcAddress, RpcEnv}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doAnswer, mock, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/ReceiverMetricSystemBuilderSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/ReceiverMetricSystemBuilderSuite.scala
@@ -2,8 +2,8 @@ package org.apache.spark.metrics
 
 import org.apache.spark._
 import org.apache.spark.rpc.{RpcEndpoint, RpcEndpointRef, RpcEnv}
-import org.mockito.Matchers
-import org.mockito.Matchers.{any, argThat}
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 
@@ -15,6 +15,7 @@ object ReceiverMetricSystemBuilderSuite {
 
 class ReceiverMetricSystemBuilderSuite extends SparkFunSuite
   with BeforeAndAfterEach {
+  import TestImplicits._
 
   private var env: SparkEnv = null
   private var rpcEnv: RpcEnv = null
@@ -95,13 +96,12 @@ class ReceiverMetricSystemBuilderSuite extends SparkFunSuite
       builder.registerCounter(ReceiverMetricSystemBuilderSuite.CounterName)
     })
     builder.build
-    import TestImplicits.matcher
     ///verify(this.rpcMetricsReceiverRef).send(argThat((message: CounterMessage) => message.value === 1))
     verify(metricsSystem, times(1)).registerSource(
       argThat((source: org.apache.spark.metrics.source.Source) => source.metricRegistry.counter(
         ReceiverMetricSystemBuilderSuite.CounterName
       ) != null))
-    verify(rpcEnv, times(1)).setupEndpoint(Matchers.eq(
+    verify(rpcEnv, times(1)).setupEndpoint(ArgumentMatchers.eq(
       ReceiverMetricSystemBuilderSuite.EndpointName), any[RpcMetricsReceiver]
     )
   }

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
@@ -59,7 +59,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
   private var settableGauge: SettableGauge[Long] = null
 
 
-  val clockClazz = loadOneOf("com.codahale.metrics.jvm.CpuTimeClock","com.codahale.metrics.Clock.CpuTimeClock").get
+  val clockClazz = loadOneOf("com.codahale.metrics.jvm.CpuTimeClock","com.codahale.metrics.Clock$CpuTimeClock").get
     .asInstanceOf[Class[_<:Clock]]
 
   /**

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
@@ -3,13 +3,16 @@ package org.apache.spark.metrics
 import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics._
+import com.codahale.metrics.Clock._
 import org.apache.spark._
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler.TaskSchedulerImpl
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterEach, PrivateMethodTester}
+
+import scala.util.Try
 
 class CustomMetric extends Metric {
   def foo(value: Int) = {
@@ -56,7 +59,13 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
   private var meter: Meter = null
   private var timer: Timer = null
   private var settableGauge: SettableGauge[Long] = null
+  import TestImplicits._
 
+  val ClockClass: Class[_<:Clock] = Try{
+    Class.forName("com.codahale.metrics.jvm.CpuTimeClock")
+  }
+    .getOrElse(Class.forName("com.codahale.metrics.Clock.CpuTimeClock"))
+    .asInstanceOf[Class[_<:Clock]]
   /**
     * Before each test, set up the SparkContext and a custom [[RpcMetricsReceiver]]
     * that uses a manual clock.
@@ -155,7 +164,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       RpcMetricsReceiverSuite.CounterName,
       value
     ))
-    verify(counter, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).inc(Matchers.eq(value))
+    verify(counter, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).inc(ArgumentMatchers.eq(value))
   }
 
   test("CounterMessage received with invalid name and inc() not called") {
@@ -177,7 +186,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       value,
       classOf[ExponentiallyDecayingReservoir]
     ))
-    verify(histogram, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).update(Matchers.eq(value))
+    verify(histogram, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).update(ArgumentMatchers.eq(value))
   }
 
   test("HistogramMessage received with invalid name and update() not called") {
@@ -210,7 +219,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       value,
       classOf[Clock.UserTimeClock]
     ))
-    verify(meter, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).mark(Matchers.eq(value))
+    verify(meter, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).mark(ArgumentMatchers.eq(value))
   }
 
   test("MeterMessage received with invalid name and mark() not called") {
@@ -230,7 +239,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       RpcMetricsReceiverSuite.MetricNamespace,
       RpcMetricsReceiverSuite.MeterName,
       value,
-      classOf[Clock.CpuTimeClock]
+      clockClass = ClockClass
     ))
     verify(meter, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout).times(0)).mark(any[Long])
   }
@@ -246,8 +255,8 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       classOf[Clock.UserTimeClock]
     ))
     verify(timer, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).update(
-      Matchers.eq(value),
-      Matchers.eq(TimeUnit.NANOSECONDS)
+      ArgumentMatchers.eq(value),
+      ArgumentMatchers.eq(TimeUnit.NANOSECONDS)
     )
   }
 
@@ -291,7 +300,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       value,
       TimeUnit.NANOSECONDS,
       classOf[ExponentiallyDecayingReservoir],
-      classOf[Clock.CpuTimeClock]
+      clockClass = ClockClass
     ))
     verify(timer, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout).times(0)).update(
       any[Long],
@@ -306,7 +315,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       RpcMetricsReceiverSuite.SettableGaugeName,
       value
     ))
-    verify(settableGauge, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).set(Matchers.eq(value))
+    verify(settableGauge, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).set(ArgumentMatchers.eq(value))
   }
 
   test("SettableGaugeMessage received with invalid name and set() not called") {
@@ -335,7 +344,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
     ))
 
     verify(rpcMetricsReceiver, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout).times(2)).receive
-    verify(counter, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).inc(Matchers.eq(value))
+    verify(counter, timeout(RpcMetricsReceiverSuite.DefaultRpcEventLoopTimeout)).inc(ArgumentMatchers.eq(value))
   }
 
 }

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/TestUtils.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/TestUtils.scala
@@ -3,9 +3,7 @@ package org.apache.spark.metrics
 import org.mockito.ArgumentMatcher
 
 import scala.reflect.ClassTag
-import scala.reflect.runtime.currentMirror
-import scala.tools.reflect.ToolBox
-import scala.util.{Properties, Try}
+import scala.util.Try
 
 object TestImplicits {
 
@@ -14,6 +12,15 @@ object TestImplicits {
   implicit def matcher[T](f: (T) => Boolean): ArgumentMatcher[T] = new ArgumentMatcher[T] {
     override def matches(argument: T): Boolean = f(argument)
   }
+
+  implicit class ListImplicits[T](lst: List[T]) {
+    def insertAt(index: Int, objs: T*): List[T] = {
+      val (a, b) = lst.splitAt(index)
+      a ::: objs.toList ::: b
+    }
+
+  }
+
 }
 
 object TestUtils {
@@ -23,21 +30,27 @@ object TestUtils {
     field
   }
 
-  def conditionalCode(spark2ver: String, spark3ver: String): Any = {
-    val toolbox = currentMirror.mkToolBox()
-    import toolbox.{eval, parse}
-    if (Properties.versionString.stripPrefix("version ").startsWith("2.11"))
-      eval(parse(spark2ver))
-    else
-      eval(parse(spark3ver))
+  def newInstance[T](clazz: Class[T], args: Any*): Option[T] = {
+    val argslst = args.map(_.asInstanceOf[Object])
+    val res = clazz.getConstructors
+      .toStream
+      .filter(_.getParameterTypes.length == args.size)
+    val res2 = res
+      .map(c => Try {
+        c.newInstance(argslst: _*)
+      })
+      .flatMap(_.toOption)
+      .headOption
+      .map(_.asInstanceOf[T])
+    res2
   }
 
-  def loadOneOf(clazzPaths: String*) =
+  def loadOneOf(clazzPaths: String*): Option[Class[_]] =
     clazzPaths
       .toStream
       .map(cl => Try {
         Class.forName(cl)
       })
       .find(_.isSuccess)
-      .get
+      .map(_.get)
 }

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/TestUtils.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/TestUtils.scala
@@ -3,14 +3,17 @@ package org.apache.spark.metrics
 import org.mockito.ArgumentMatcher
 
 import scala.reflect.ClassTag
+import scala.reflect.runtime.currentMirror
+import scala.tools.reflect.ToolBox
+import scala.util.{Properties, Try}
 
 object TestImplicits {
+
   import scala.language.implicitConversions
 
-  implicit def matcher[T](f: (T) => Boolean): ArgumentMatcher[T] =
-    new ArgumentMatcher[T]() {
-      def matches(o: Any): Boolean = f(o.asInstanceOf[T])
-    }
+  implicit def matcher[T](f: (T) => Boolean): ArgumentMatcher[T] = new ArgumentMatcher[T] {
+    override def matches(argument: T): Boolean = f(argument)
+  }
 }
 
 object TestUtils {
@@ -19,4 +22,22 @@ object TestUtils {
     field.setAccessible(true)
     field
   }
+
+  def conditionalCode(spark2ver: String, spark3ver: String): Any = {
+    val toolbox = currentMirror.mkToolBox()
+    import toolbox.{eval, parse}
+    if (Properties.versionString.stripPrefix("version ").startsWith("2.11"))
+      eval(parse(spark2ver))
+    else
+      eval(parse(spark3ver))
+  }
+
+  def loadOneOf(clazzPaths: String*) =
+    clazzPaths
+      .toStream
+      .map(cl => Try {
+        Class.forName(cl)
+      })
+      .find(_.isSuccess)
+      .get
 }

--- a/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
@@ -3,71 +3,55 @@ package org.apache.spark.sql.streaming
 import java.util.UUID
 
 import org.apache.spark.listeners.ListenerSuite
+import org.apache.spark.metrics.TestImplicits._
 import org.apache.spark.metrics.TestUtils
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.streaming.StreamingQueryListener.{QueryProgressEvent, QueryStartedEvent, QueryTerminatedEvent}
 import org.scalatest.BeforeAndAfterEach
 
+import scala.collection.JavaConversions.mapAsJavaMap
+
 object LogAnalyticsStreamingQueryListenerSuite {
-  val queryStartedEvent = TestUtils.conditionalCode(
-    "new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, \"name\")",
-    "new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, \"name\", (System.currentTimeMillis()/1000).toString)"
-  ).asInstanceOf[QueryStartedEvent]
+  //Spark3 requires 1 more argument than spark 2.4
+  val queryStartedEvent = TestUtils
+    .newInstance(classOf[QueryStartedEvent], UUID.randomUUID, UUID.randomUUID, "name")
+    .orElse(TestUtils.newInstance(classOf[QueryStartedEvent], UUID.randomUUID, UUID.randomUUID, "name", (System.currentTimeMillis() / 1000).toString))
+    .get
+
   val queryTerminatedEvent = new QueryTerminatedEvent(UUID.randomUUID, UUID.randomUUID, None)
-  val queryProgressEvent = TestUtils.conditionalCode(
-    """
-      |new QueryProgressEvent(
-      |    new StreamingQueryProgress(
-      |      UUID.randomUUID,
-      |      UUID.randomUUID,
-      |      null,
-      |      ListenerSuite.EPOCH_TIME_AS_ISO8601,
-      |      2L,
-      |      mapAsJavaMap(Map("total" -> 0L)),
-      |      mapAsJavaMap(Map.empty[String, String]),
-      |      Array(new StateOperatorProgress(
-      |        0, 1, 2)),
-      |      Array(
-      |        new SourceProgress(
-      |          "source",
-      |          "123",
-      |          "456",
-      |          678,
-      |          Double.NaN,
-      |          Double.NegativeInfinity
-      |        )
-      |      ),
-      |      new SinkProgress("sink"),mapAsJavaMap(Map[String,Row]())
-      |    )
-      |  )
-      |""".stripMargin,
-    """
-      |new QueryProgressEvent(
-      |    new StreamingQueryProgress(
-      |      UUID.randomUUID,
-      |      UUID.randomUUID,
-      |      null,
-      |      ListenerSuite.EPOCH_TIME_AS_ISO8601,
-      |      1234L,
-      |      2L,
-      |      mapAsJavaMap(Map("total" -> 0L)),
-      |      mapAsJavaMap(Map.empty[String, String]),
-      |      Array(new StateOperatorProgress(
-      |        0, 1, 2)),
-      |      Array(
-      |        new SourceProgress(
-      |          "source",
-      |          "123",
-      |          "456",
-      |          678,
-      |          Double.NaN,
-      |          Double.NegativeInfinity
-      |        )
-      |      ),
-      |      new SinkProgress("sink"),mapAsJavaMap(Map[String,Row]())
-      |    )
-      |  )
-      |""".stripMargin
-  ).asInstanceOf[QueryProgressEvent]
+  val queryProgressEvent = {
+
+    val spark2args = List[Any](
+      UUID.randomUUID,
+      UUID.randomUUID,
+      null,
+      ListenerSuite.EPOCH_TIME_AS_ISO8601,
+      2L,
+      mapAsJavaMap(Map("total" -> 0L)),
+      mapAsJavaMap(Map.empty[String, String]),
+      Array(new StateOperatorProgress(
+        0, 1, 2)),
+      Array(
+        new SourceProgress(
+          "source",
+          "123",
+          "456",
+          678,
+          Double.NaN,
+          Double.NegativeInfinity
+        )
+      ),
+      new SinkProgress("sink"), mapAsJavaMap(Map[String, Row]())
+    )
+
+    val spark3args = spark2args.insertAt(4, 1234L)
+
+    val streamingQueryProgress = TestUtils.newInstance(classOf[StreamingQueryProgress], spark2args:_*)
+      .orElse(TestUtils.newInstance(classOf[StreamingQueryProgress], spark3args:_*))
+      .get
+
+    new QueryProgressEvent(streamingQueryProgress)
+  }
 }
 
 class LogAnalyticsStreamingQueryListenerSuite extends ListenerSuite

--- a/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
@@ -24,7 +24,7 @@ object LogAnalyticsStreamingQueryListenerSuite {
     val spark2args = List[Any](
       UUID.randomUUID,
       UUID.randomUUID,
-      null,
+      "test",
       ListenerSuite.EPOCH_TIME_AS_ISO8601,
       2L,
       mapAsJavaMap(Map("total" -> 0L)),
@@ -41,10 +41,10 @@ object LogAnalyticsStreamingQueryListenerSuite {
           Double.NegativeInfinity
         )
       ),
-      new SinkProgress("sink"), mapAsJavaMap(Map[String, Row]())
+      new SinkProgress("sink")
     )
 
-    val spark3args = spark2args.insertAt(4, 1234L)
+    val spark3args = spark2args.insertAt(4, 1234L) ::: List(mapAsJavaMap(Map[String, Row]()))
 
     val streamingQueryProgress = TestUtils.newInstance(classOf[StreamingQueryProgress], spark2args:_*)
       .orElse(TestUtils.newInstance(classOf[StreamingQueryProgress], spark3args:_*))


### PR DESCRIPTION
### Changes proposed in this PR
I have added the support for spark 3 using the same codebase and same tests for both versions of spark and scala. 

### Code changes:
StreamingListenerHandlers.scala:
It looks like a method was renamed in the new release of spark, so I am taking away the optional "override" keyword and adding the new method as well. 

### Changes to unit tests
The new version of the io.dropwizard.metrics:metrics-core has moved the CpuTimeClock class. The only way to support both versions with the same tests is to instantiate the object using reflections. 

Spark 3 has also added some new parameters to the constructors of events. I decided to use the same approach to not duplicate code: I am instantiating the objects of those classes using reflections.

Reflections add a lot of complexity to the unit tests, but it enables us to reuse the same unit tests and to not duplicate code. The alternative would be to duplicate code for the unit tests, but then we would have to maintain two unit test suites, which is not ideal as well. Unfortunately, none of the choices are good in my opinion. 

Fix #92 