### PR TITLE
Add filtering capability to Spark Monitoring library

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ SparkMetric_CL
 | extend executor=strcat(sname[0], ".", sname[1])
 | project TimeGenerated, cpuTime=count_d / 100000
 ```
+## Filtering
+
+The library is configurable to limit the volume of logs that are sent to each of the different Azure Monitor log types.  See [filtering](./docs/filtering.md) for more details.
 
 ## Debugging
 

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -10,7 +10,7 @@ The Spark Monitoring Library can generate large volumes of logging and metrics d
 
 ## Limiting events in SparkListenerEvent_CL
 
-You can uncomment and edit the `LA_SPARKLISTENEREVENT_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where Event_s matches the regex.
+You can uncomment and edit the `LA_SPARKLISTENEREVENT_REGEX` environment variable that is included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where Event_s matches the regex.
 
 The example below will only log events for `SparkListenerJobStart`, `SparkListenerJobEnd`, or where `org.apache.spark.sql.execution.ui.` is in the event name.
 
@@ -44,7 +44,7 @@ SparkListenerEvent_CL
 
 ## Limiting Metrics in SparkMetric_CL
 
-You can uncomment and edit the `LA_SPARKMETRIC_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where name_s matches the regex.
+You can uncomment and edit the `LA_SPARKMETRIC_REGEX` environment variable that is included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where name_s matches the regex.
 
 The example below will only log metrics where the name begins with `app` and ends in `.jvmCpuTime` or `.heap.max`.
 
@@ -92,13 +92,13 @@ The logs that propagate to SparkLoggingEvent_CL do so through a log4j appender. 
 
 ## Limiting Logs in SparkLoggingEvent_CL (Advanced)
 
-You can uncomment and edit the `LA_SPARKLOGGINGEVENT_NAME_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where logger_name_s matches the regex.
+You can uncomment and edit the `LA_SPARKLOGGINGEVENT_NAME_REGEX` environment variable that is included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where logger_name_s matches the regex.
 
 The example below will only log events from logger `com.microsoft.pnp.samplejob.StreamingQueryListenerSampleJob` or where the logger name starts with `org.apache.spark.util.Utils`.
 
 `export LA_SPARKLOGGINGEVENT_NAME_REGEX="com\.microsoft\.pnp\.samplejob\.StreamingQueryListenerSampleJob|org\.apache\.spark\.util\.Utils.*"`
 
-You can uncomment and edit the `LA_SPARKLOGGINGEVENT_MESSAGE_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where the message matches the regex.
+You can uncomment and edit the `LA_SPARKLOGGINGEVENT_MESSAGE_REGEX` environment variable that is included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where the message matches the regex.
 
 The example below will only log events where the message ends with the string `StreamingQueryListenerSampleJob` or begins with the string `FS_CONF_COMPAT`.
 

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -1,0 +1,111 @@
+# Filtering
+
+## Introduction
+
+The Spark Monitoring Library can generate large volumes of logging and metrics data.  This page describes the ways that you can limit the events that are forwarded to Azure Monitor.
+
+> Note: All regex filters below are implemented with java.lang.String.matches(...). This implementation essentially appends ^...$ around the regular expression, so the entire string must match the regex.  If you need to allow for other values you should include .* before and/or after your expression.
+
+> Note: The REGEX value(s) should be surrounded by double quotes as noted in the examples so that the characters in the regular expression(s) are not interpretted by the shell.
+
+## Limiting events in SparkListenerEvent_CL
+
+You can uncomment and edit the `LA_SPARKLISTENEREVENT_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where Event_s matches the regex.
+
+The example below will only log events for `SparkListenerJobStart`, `SparkListenerJobEnd`, or where `org.apache.spark.sql.execution.ui.` is in the event name.
+
+`export LA_SPARKLISTENEREVENT_REGEX="SparkListenerJobEnd|SparkListenerTaskEnd|org\.apache\.spark\.sql\.execution\.ui\..*"`
+
+### Finding Event Names in Azure Monitor
+
+The following query will show counts by day for all events that have been logged to Azure Monitor:
+```kusto
+SparkListenerEvent_CL
+| project TimeGenerated, Event_s
+| summarize Count=count() by tostring(Event_s), bin(TimeGenerated, 1d)
+```
+
+### Events Noted in SparkListenerEvent_CL
+
+* SparkListenerExecutorAdded
+* SparkListenerBlockManagerAdded
+* org.apache.spark.sql.streaming.StreamingQueryListener$QueryStartedEvent
+* org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
+* org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
+* org.apache.spark.sql.execution.ui.SparkListenerDriverAccumUpdates
+* org.apache.spark.sql.streaming.StreamingQueryListener$QueryTerminatedEvent
+* SparkListenerJobStart
+* SparkListenerStageSubmitted
+* SparkListenerTaskStart
+* SparkListenerTaskEnd
+* org.apache.spark.sql.streaming.StreamingQueryListener$QueryProgressEvent
+* SparkListenerStageCompleted
+* SparkListenerJobEnd
+
+## Limiting Metrics in SparkMetric_CL
+
+You can uncomment and edit the `LA_SPARKMETRIC_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where name_s matches the regex.
+
+The example below will only log metrics where the name begins with `app` and ends in `.jvmCpuTime` or `.heap.max`.
+
+`export LA_SPARKMETRIC_REGEX="app.*\.jvmCpuTime|app.*\.heap.max`
+
+### Finding Metric Names in Azure Monitor
+
+Query to find all metric prefixes and counts by day:
+
+```kusto
+SparkMetric_CL
+| project nameprefix=split(tostring(name_s),".")[0], TimeGenerated
+| summarize Count=count() by tostring(nameprefix), bin(TimeGenerated, 1d)
+```
+If you want to get more granular, the full names can be seen with the following query. Note: This will include a large number of metrics including for specific Spark applications.
+
+```kusto
+SparkMetric_CL
+| project name_s, TimeGenerated
+| summarize Count=count() by tostring(name_s), bin(TimeGenerated, 1d)
+```
+
+### Metric Name Prefixes Noted in SparkMetric_CL
+
+* jvm
+* worker
+* Databricks
+* HiveExternalCatalog
+* CodeGenerator
+* application
+* master
+* app-20201014133042-0000 - Note: This prefix includes all metrics for a specific Spark application run.
+* shuffleService
+* SparkStatusTracker
+
+## Limiting Logs in SparkLoggingEvent_CL (Basic)
+
+The logs that propagate to SparkLoggingEvent_CL do so through a log4j appender.  This can be configured by altering the spark-monitoring.sh script that is responsible for writing the log4j.properties file. The script at [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) can be modified to set the threshold for events to be forwarded.  A commented example is included in the script.
+
+```bash
+# Commented line below shows how to set the threshhold for logging to only capture events that are
+# level ERROR or more severe.
+# log4j.appender.logAnalyticsAppender.Threshold=ERROR
+```
+
+## Limiting Logs in SparkLoggingEvent_CL (Advanced)
+
+You can uncomment and edit the `LA_SPARKLOGGINGEVENT_NAME_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where logger_name_s matches the regex.
+
+The example below will only log events from logger `com.microsoft.pnp.samplejob.StreamingQueryListenerSampleJob` or where the logger name starts with `org.apache.spark.util.Utils`.
+
+`export LA_SPARKLOGGINGEVENT_NAME_REGEX="com\.microsoft\.pnp\.samplejob\.StreamingQueryListenerSampleJob|org\.apache\.spark\.util\.Utils.*"`
+
+You can uncomment and edit the `LA_SPARKLOGGINGEVENT_MESSAGE_REGEX` environment variable that included included in [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) to limit the logging to only include events where the message matches the regex.
+
+The example below will only log events where the message ends with the string `StreamingQueryListenerSampleJob` or begins with the string `FS_CONF_COMPAT`.
+
+`export LA_SPARKLOGGINGEVENT_MESSAGE_REGEX=".*StreamingQueryListenerSampleJob|FS_CONF_COMPAT.*"`
+
+## Performance Considerations
+
+You should be mindful of using complicated Regular Expressions as they have to be evaluated for every logged event or metric.  Simple whole-string matches should be relatively performent, or `pattern.*` expressions that will match the beginning of strings.
+
+> Warning: Filtering on the logging event message with `LA_SPARKLOGGINGEVENT_MESSAGE_REGEX` should be considered experimental. Some components generate very large message strings and processing the `.matches` operation on these strings could cause a significant burden on the cluster nodes.

--- a/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/listeners/sink/loganalytics/LogAnalyticsListenerSink.scala
+++ b/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/listeners/sink/loganalytics/LogAnalyticsListenerSink.scala
@@ -4,14 +4,15 @@ import com.microsoft.pnp.client.loganalytics.{LogAnalyticsClient, LogAnalyticsSe
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.listeners.sink.SparkListenerSink
-import org.json4s.JsonAST
+import org.json4s.{JsonAST, DefaultFormats}
 import org.json4s.jackson.JsonMethods.compact
 
 import scala.util.control.NonFatal
 
 class LogAnalyticsListenerSink(conf: SparkConf) extends SparkListenerSink with Logging {
   private val config = new LogAnalyticsListenerSinkConfiguration(conf)
-
+  implicit val formats = DefaultFormats
+  private var filterRegex = sys.env.getOrElse("LA_SPARKLISTENEREVENT_REGEX", "")
 
   protected lazy val logAnalyticsBufferedClient = new LogAnalyticsSendBufferClient(
     new LogAnalyticsClient(
@@ -23,9 +24,13 @@ class LogAnalyticsListenerSink(conf: SparkConf) extends SparkListenerSink with L
     try {
       event match {
         case Some(j) => {
-          val jsonString = compact(j)
-          logDebug(s"Sending event to Log Analytics: ${jsonString}")
-          logAnalyticsBufferedClient.sendMessage(jsonString, "SparkEventTime")
+          val event = (j \ "Event").extract[String]
+          if(filterRegex=="" || event.matches(filterRegex))
+          {
+            val jsonString = compact(j)
+            logDebug(s"Sending event to Log Analytics: ${jsonString}")
+            logAnalyticsBufferedClient.sendMessage(jsonString, "SparkEventTime")
+          }
         }
         case None =>
       }

--- a/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/metrics/sink/loganalytics/LogAnalyticsReporter.scala
+++ b/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/metrics/sink/loganalytics/LogAnalyticsReporter.scala
@@ -36,6 +36,14 @@ object LogAnalyticsReporter {
     private var rateUnit = TimeUnit.SECONDS
     private var durationUnit = TimeUnit.MILLISECONDS
     private var filter = MetricFilter.ALL
+    private var filterRegex = sys.env.getOrElse("LA_SPARKMETRIC_REGEX", "")
+    if(filterRegex != "") {
+      filter = new MetricFilter() {
+        override def matches(name: String, metric: Metric): Boolean = {
+          name.matches(filterRegex)
+        }
+      }
+    }
     private var logType = "SparkMetrics"
     private var workspaceId: String = null
     private var workspaceKey: String = null

--- a/src/spark-listeners-loganalytics/src/test/java/com/microsoft/pnp/logging/loganalytics/LogAnalyticsAppenderTest.java
+++ b/src/spark-listeners-loganalytics/src/test/java/com/microsoft/pnp/logging/loganalytics/LogAnalyticsAppenderTest.java
@@ -69,6 +69,9 @@ public class LogAnalyticsAppenderTest {
     public void FilterShouldDenyNameRegex() throws IllegalAccessException {
         nameregex.set(null,"12.*34");
         messageregex.set(null,"");
+        when(test.getLoggerName()).thenReturn("x12_This_is_a_test_34x");
+        when(test.getRenderedMessage()).thenReturn("This is a generic log message");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
         when(test.getLoggerName()).thenReturn("12_This_is_a_test_3456789");
         when(test.getRenderedMessage()).thenReturn("This is a generic log message");
         assertEquals(sut.getFilter().decide(test),Filter.DENY);
@@ -78,9 +81,9 @@ public class LogAnalyticsAppenderTest {
         nameregex.set(null,"");
         messageregex.set(null,"(?i)((?!password).)*");// Only match if the message does not contain the word password
         when(test.getLoggerName()).thenReturn("12_This_is_a_test_34");
-        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged password: not_a_password");
+        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged password: randomstring");
         assertEquals(sut.getFilter().decide(test),Filter.DENY);
-        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged Password: not_a_password");
+        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged Password: randomstring");
         assertEquals(sut.getFilter().decide(test),Filter.DENY);
     }
     @Test
@@ -90,5 +93,22 @@ public class LogAnalyticsAppenderTest {
         when(test.getLoggerName()).thenReturn("12_This_is_a_test_34");
         when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged Username: not_a_user");
         assertEquals(sut.getFilter().decide(test),Filter.NEUTRAL);
+    }
+     @Test
+    public void FilterShouldDenyNameMessageRegex() throws IllegalAccessException {
+        nameregex.set(null,"12.*34");
+        messageregex.set(null,"(?i)((?!password).)*");// Only match if the message does not contain the word password
+        // message does not match
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_34");
+        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged password: randomstring");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
+        // name doesn't match
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_3456789");
+        when(test.getRenderedMessage()).thenReturn("This is a generic log message");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
+        // name and message do not match
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_3456789");
+        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged password: randomstring");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
     }
 }

--- a/src/spark-listeners-loganalytics/src/test/java/com/microsoft/pnp/logging/loganalytics/LogAnalyticsAppenderTest.java
+++ b/src/spark-listeners-loganalytics/src/test/java/com/microsoft/pnp/logging/loganalytics/LogAnalyticsAppenderTest.java
@@ -1,0 +1,94 @@
+package com.microsoft.pnp.logging.loganalytics;
+
+import com.microsoft.pnp.client.loganalytics.LogAnalyticsClient;
+import junit.framework.TestCase;
+import org.apache.http.client.HttpClient;
+import org.apache.log4j.spi.Filter;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.*;
+
+public class LogAnalyticsAppenderTest {
+
+    Field nameregex;
+    Field messageregex;
+    LogAnalyticsAppender sut;
+    LoggingEvent test = mock(LoggingEvent.class);
+
+    @Before
+    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+        sut = new LogAnalyticsAppender();
+
+        // These fields are set private static from environment at startup, but we need different values for testing so
+        // we are changing them to be accessible so that we can modify for testing.
+        nameregex = LogAnalyticsAppender.class.getDeclaredField("LA_SPARKLOGGINGEVENT_NAME_REGEX");
+        messageregex = LogAnalyticsAppender.class.getDeclaredField("LA_SPARKLOGGINGEVENT_MESSAGE_REGEX");
+        nameregex.setAccessible(true);
+        messageregex.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField( "modifiers" );
+        modifiersField.setAccessible( true );
+        modifiersField.setInt( nameregex, nameregex.getModifiers() & ~Modifier.FINAL );
+        modifiersField.setInt( messageregex, messageregex.getModifiers() & ~Modifier.FINAL );
+    }
+
+    @Test
+    public void FilterShouldWorkWithEmptyEnv() throws IllegalAccessException {
+        nameregex.set(null,"");
+        messageregex.set(null,"");
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_34");
+        when(test.getRenderedMessage()).thenReturn("This is a generic log message");
+        assertEquals(sut.getFilter().decide(test),Filter.NEUTRAL);
+    }
+    @Test
+    public void FilterShouldRejectOrgApacheHttp() throws IllegalAccessException {
+        nameregex.set(null,"");
+        messageregex.set(null,"");
+        when(test.getLoggerName()).thenReturn("org.apache.http.this.is.a.test");
+        when(test.getRenderedMessage()).thenReturn("This is a generic log message");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
+    }
+    @Test
+    public void FilterShouldAllowNameRegex() throws IllegalAccessException {
+        nameregex.set(null,"12.*34");
+        messageregex.set(null,"");
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_34");
+        when(test.getRenderedMessage()).thenReturn("This is a generic log message");
+        assertEquals(sut.getFilter().decide(test),Filter.NEUTRAL);
+    }
+    @Test
+    public void FilterShouldDenyNameRegex() throws IllegalAccessException {
+        nameregex.set(null,"12.*34");
+        messageregex.set(null,"");
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_3456789");
+        when(test.getRenderedMessage()).thenReturn("This is a generic log message");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
+    }
+    @Test
+    public void FilterShouldDenyMessageRegex() throws IllegalAccessException {
+        nameregex.set(null,"");
+        messageregex.set(null,"(?i)((?!password).)*");// Only match if the message does not contain the word password
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_34");
+        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged password: not_a_password");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
+        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged Password: not_a_password");
+        assertEquals(sut.getFilter().decide(test),Filter.DENY);
+    }
+    @Test
+    public void FilterShouldAllowMessageRegex() throws IllegalAccessException {
+        nameregex.set(null,"");
+        messageregex.set(null,"(?i)((?!password).)*");// Only match if the message does not contain the word password
+        when(test.getLoggerName()).thenReturn("12_This_is_a_test_34");
+        when(test.getRenderedMessage()).thenReturn("This message is pretending to return a logged Username: not_a_user");
+        assertEquals(sut.getFilter().decide(test),Filter.NEUTRAL);
+    }
+}

--- a/src/spark-listeners/scripts/spark-monitoring.sh
+++ b/src/spark-listeners/scripts/spark-monitoring.sh
@@ -25,6 +25,26 @@ export AZ_RSRC_GRP_NAME=
 export AZ_RSRC_PROV_NAMESPACE=
 export AZ_RSRC_TYPE=
 export AZ_RSRC_NAME=
+
+# Note: All REGEX filters below are implemented with java.lang.String.matches(...).  This implementation essentially appends ^...$ around
+# the regular expression, so the entire string must match the regex.  If you need to allow for other values you should include .* before and/or
+# after your expression.
+
+# Add a quoted regex value to filter the events for SparkListenerEvent_CL, the log will only include events where Event_s matches the regex.
+# Commented example below will only log events for SparkListenerJobStart, SparkListenerJobEnd, or where "org.apache.spark.sql.execution.ui."
+# is in the event name.
+# export LA_SPARKLISTENEREVENT_REGEX="SparkListenerJobEnd|SparkListenerTaskEnd|org\.apache\.spark\.sql\.execution\.ui\..*"
+
+# Add a quoted regex value to filter the events for SparkMetric_CL, the log will only include events where name_s matches the regex.
+# Commented example below will only log metrics where the name begins with app and ends in .jvmCpuTime or .heap.max.
+# export LA_SPARKMETRIC_REGEX="app.*\.jvmCpuTime|app.*\.heap.max"
+
+# Add a quoted regex value to filter the events for SparkLoggingEvent_CL, the log will only include events where logger_name_s matches the name regex
+# or where the Message matches the message regex.  If both are specified, then both must be matched for the log to be sent.
+# Commented examples below will only log messages where the logger name is com.microsoft.pnp.samplejob.StreamingQuerySampleJob or begins with
+# org.apache.spark.util.Utils, or where the Message ends with the string `StreamingQueryListenerSampleJob` or begins with the string `FS_CONF_COMPAT`.
+# export LA_SPARKLOGGINGEVENT_NAME_REGEX="com\.microsoft\.pnp\.samplejob\.StreamingQueryListenerSampleJob|org\.apache\.spark\.util\.Utils.*"
+# export LA_SPARKLOGGINGEVENT_MESSAGE_REGEX=".*StreamingQueryListenerSampleJob|FS_CONF_COMPAT.*"
 EOF
 
 STAGE_DIR=/dbfs/databricks/spark-monitoring
@@ -85,6 +105,9 @@ tee -a ${LOG4J_CONFIG_FILE} << EOF
 # logAnalytics
 log4j.appender.logAnalyticsAppender=com.microsoft.pnp.logging.loganalytics.LogAnalyticsAppender
 log4j.appender.logAnalyticsAppender.filter.spark=com.microsoft.pnp.logging.SparkPropertyEnricher
+# Commented line below shows how to set the threshhold for logging to only capture events that are
+# level ERROR or more severe.
+# log4j.appender.logAnalyticsAppender.Threshold=ERROR
 EOF
 
 echo "END: Updating $LOG4J_CONFIG_FILE with Log Analytics appender"

--- a/src/spark-listeners/scripts/spark-monitoring.sh
+++ b/src/spark-listeners/scripts/spark-monitoring.sh
@@ -41,7 +41,7 @@ export AZ_RSRC_NAME=
 
 # Add a quoted regex value to filter the events for SparkLoggingEvent_CL, the log will only include events where logger_name_s matches the name regex
 # or where the Message matches the message regex.  If both are specified, then both must be matched for the log to be sent.
-# Commented examples below will only log messages where the logger name is com.microsoft.pnp.samplejob.StreamingQuerySampleJob or begins with
+# Commented examples below will only log messages where the logger name is com.microsoft.pnp.samplejob.StreamingQueryListenerSampleJob or begins with
 # org.apache.spark.util.Utils, or where the Message ends with the string `StreamingQueryListenerSampleJob` or begins with the string `FS_CONF_COMPAT`.
 # export LA_SPARKLOGGINGEVENT_NAME_REGEX="com\.microsoft\.pnp\.samplejob\.StreamingQueryListenerSampleJob|org\.apache\.spark\.util\.Utils.*"
 # export LA_SPARKLOGGINGEVENT_MESSAGE_REGEX=".*StreamingQueryListenerSampleJob|FS_CONF_COMPAT.*"

--- a/src/spark-listeners/scripts/spark-monitoring.sh
+++ b/src/spark-listeners/scripts/spark-monitoring.sh
@@ -32,8 +32,8 @@ export AZ_RSRC_NAME=
 
 # Add a quoted regex value to filter the events for SparkListenerEvent_CL, the log will only include events where Event_s matches the regex.
 # Commented example below will only log events for SparkListenerJobStart, SparkListenerJobEnd, or where "org.apache.spark.sql.execution.ui."
-# is in the event name.
-# export LA_SPARKLISTENEREVENT_REGEX="SparkListenerJobEnd|SparkListenerTaskEnd|org\.apache\.spark\.sql\.execution\.ui\..*"
+# is is the start of the event name.
+# export LA_SPARKLISTENEREVENT_REGEX="SparkListenerJobStart|SparkListenerJobEnd|org\.apache\.spark\.sql\.execution\.ui\..*"
 
 # Add a quoted regex value to filter the events for SparkMetric_CL, the log will only include events where name_s matches the regex.
 # Commented example below will only log metrics where the name begins with app and ends in .jvmCpuTime or .heap.max.


### PR DESCRIPTION
Implement a basic regex filter for each of SparkLoggingEvent_CL, SparkMetric_CL, and SparkListenerEvent_CL.
Provide documentation and examples of how to edit the launcher script to populate the necessary environment variables.
Include documentation on how to use built-in log4j threshold based filter.

Fixes: #95 