### PR TITLE
Attempt to flush buffer on InterruptedException

### DIFF
--- a/src/spark-listeners/src/main/java/com/microsoft/pnp/client/GenericSendBufferTask.java
+++ b/src/spark-listeners/src/main/java/com/microsoft/pnp/client/GenericSendBufferTask.java
@@ -151,6 +151,11 @@ public abstract class GenericSendBufferTask<T> implements Runnable {
 
             process(datas);
         } catch (InterruptedException e) {
+            // If the thread is interrupted, we should make a best effort to deliver the messages in the buffer.
+            // This may result in duplicated messages if the thread is interrupted late in the execution of process(...)
+            // but this is better than missing messages that might have information on an important error.
+            process(new ArrayList<>(this.datas));
+            this.datas.clear();
         } catch (RuntimeException e) {
             throw e;
         } catch (Error e) {

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/CustomMetricsSystemSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/CustomMetricsSystemSuite.scala
@@ -42,6 +42,7 @@ class MetricsSystemsSuite extends SparkFunSuite
       .setMaster("local[2]")
       .setAppName("test")
       .set("spark.dynamicAllocation.testing", "true")
+      .set("spark.driver.allowMultipleContexts", "true")
     sc = new SparkContext(conf)
     env = mock(classOf[SparkEnv])
     rpcEnv = mock(classOf[RpcEnv])

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
@@ -58,7 +58,6 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
   private var timer: Timer = null
   private var settableGauge: SettableGauge[Long] = null
 
-
   val clockClazz = loadOneOf("com.codahale.metrics.jvm.CpuTimeClock","com.codahale.metrics.Clock$CpuTimeClock").get
     .asInstanceOf[Class[_<:Clock]]
 
@@ -72,6 +71,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
       .setMaster("local[2]")
       .setAppName("test")
       .set("spark.dynamicAllocation.testing", "true")
+      .set("spark.driver.allowMultipleContexts", "true")
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)


### PR DESCRIPTION
If the thread in GenericSendBufferTask is interrupted, attempt to process any queued messages

Fix occasional error in tests from SPARK-2243

I think this should fix the reported missing messages in #71 but I don't have a reliable way to reproduce an exception to check.