### PR TITLE
Add Spark App Name and clusterName

### DIFF
--- a/src/spark-listeners/scripts/spark-monitoring.sh
+++ b/src/spark-listeners/scripts/spark-monitoring.sh
@@ -18,6 +18,7 @@ SPARK_CONF_DIR=$SPARK_HOME/conf
 # header as part of the request
 tee -a "$SPARK_CONF_DIR/spark-env.sh" << EOF
 export DB_CLUSTER_ID=$DB_CLUSTER_ID
+export DB_CLUSTER_NAME=$DB_CLUSTER_NAME
 export LOG_ANALYTICS_WORKSPACE_ID=
 export LOG_ANALYTICS_WORKSPACE_KEY=
 export AZ_SUBSCRIPTION_ID=

--- a/src/spark-listeners/src/main/scala/com/microsoft/pnp/SparkInformation.scala
+++ b/src/spark-listeners/src/main/scala/com/microsoft/pnp/SparkInformation.scala
@@ -8,12 +8,14 @@ object SparkInformation {
   // in the internal config package, so these should be replaced with those.
   private val EXECUTOR_ID = "spark.executor.id"
   private val APPLICATION_ID = "spark.app.id"
+  private val APPLICATION_NAME = "spark.app.name"
 
   // Databricks-specific
   private val DB_CLUSTER_ID = "spark.databricks.clusterUsageTags.clusterId"
   private val DB_CLUSTER_NAME = "spark.databricks.clusterUsageTags.clusterName"
   // This is the environment variable name set in our init script.
   private val DB_CLUSTER_ID_ENVIRONMENT_VARIABLE = "DB_CLUSTER_ID"
+  private val DB_CLUSTER_NAME_ENVIRONMENT_VARIABLE = "DB_CLUSTER_NAME"
 
   def get(): Map[String, String] = {
     // We might want to improve this to pull valid class names from the beginning of the command
@@ -46,6 +48,7 @@ object SparkInformation {
         val conf = e.conf
         Map(
           "applicationId" -> conf.getOption(APPLICATION_ID),
+          "applicationName" -> conf.getOption(APPLICATION_NAME),
           "clusterId" -> conf.getOption(DB_CLUSTER_ID),
           "clusterName" -> conf.getOption(DB_CLUSTER_NAME),
           "executorId" -> Option(e.executorId),
@@ -56,6 +59,7 @@ object SparkInformation {
         // If we don't have a SparkEnv, we could be on any node type, really.
         Map(
           "clusterId" -> sys.env.get(DB_CLUSTER_ID_ENVIRONMENT_VARIABLE),
+          "clusterName" -> sys.env.get(DB_CLUSTER_NAME_ENVIRONMENT_VARIABLE),
           "nodeType" -> nodeType
         )
       }


### PR DESCRIPTION
* Added spark.app.name -> allows for additional filtering in Log Analytics
* Added DB_CLUSTER_NAME -> Databricks has recently exposed DB_CLUSTER_NAME as an env, passing it for metrics outside of spark (jvm.*) helps for filtering in Log Analytics