### PR TITLE
Fixes Dependency Errors when building samples by updating artifact IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ docker run -it --rm -v %cd%:/spark-monitoring -v "%USERPROFILE%/.m2":/root/.m2 m
 docker run -it --rm -v %cd%:/spark-monitoring -v "%USERPROFILE%/.m2":/root/.m2 -w /spark-monitoring/src maven:3.6.3-jdk-8 mvn install -P "scala-2.12_spark-3.1.2"
 ```
 
+Windows Powershell:
+
+```powershell
+# To build all profiles:
+docker run -it --rm -v ${pwd}:/spark-monitoring -v ${env:userprofile}\.m2:/root/.m2 maven:3.6.3-jdk-8 /spark-monitoring/build.sh
+```
+
+```powershell
+# To build a single profile (latest long term support version):
+docker run -it --rm -v ${pwd}:/spark-monitoring -v ${env:userprofile}\.m2:/root/.m2 -w /spark-monitoring/src maven:3.6.3-jdk-8 mvn install -P "scala-2.12_spark-3.1.2"
+```
+
 ### Option 2: Maven
 
 1. Import the Maven project project object model file, _pom.xml_, located in the **/src** folder into your project. This will import two projects:
@@ -181,6 +193,12 @@ databricks runtime.
 
     ```bash
     docker run -it --rm -v %cd%/sample/spark-sample-job:/spark-sample-job -v "%USERPROFILE%/.m2":/root/.m2 -w /spark-sample-job maven:3.6.3-jdk-8 mvn install -P <maven-profile>
+    ```
+    
+    Windows Powershell:
+    
+    ```powershell
+    docker run -it --rm -v ${pwd}/sample/spark-sample-job:/spark-sample-job -v ${env:userprofile}\.m2:/root/.m2 -w /spark-sample-job maven:3.6.3-jdk-8 mvn install -P <maven-profile>
     ```
 
 1. Navigate to your Databricks workspace and create a new job, as described [here](https://docs.azuredatabricks.net/user-guide/jobs.html#create-a-job).

--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -112,6 +112,12 @@
             <version>${spark.listeners.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.pnp</groupId>
+            <artifactId>spark-listeners-loganalytics_${spark.version}_${scala.compat.version}</artifactId>
+            <version>${spark.listeners.loganalytics.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/spark-listeners-loganalytics/pom.xml
+++ b/src/spark-listeners-loganalytics/pom.xml
@@ -7,12 +7,12 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>spark-listeners-loganalytics</artifactId>
+    <artifactId>spark-listeners-loganalytics_${spark.version}_${scala.compat.version}</artifactId>
     <name>${project.artifactId}</name>
     <dependencies>
         <dependency>
             <groupId>com.microsoft.pnp</groupId>
-            <artifactId>spark-listeners</artifactId>
+            <artifactId>spark-listeners_${spark.version}_${scala.compat.version}</artifactId>
             <version>${spark.listeners.version}</version>
             <scope>compile</scope>
         </dependency>
@@ -53,7 +53,7 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>${project.artifactId}_${spark.version}_${scala.compat.version}-${project.version}</finalName>
+        <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/spark-listeners/pom.xml
+++ b/src/spark-listeners/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>spark-listeners</artifactId>
+    <artifactId>spark-listeners_${spark.version}_${scala.compat.version}</artifactId>
     <name>${project.artifactId}</name>
     <packaging>jar</packaging>
     <dependencies>
@@ -70,7 +70,7 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>${project.artifactId}_${spark.version}_${scala.compat.version}-${project.version}</finalName>
+        <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <!--<plugin>-->
             <!--<groupId>org.scalatest</groupId>-->


### PR DESCRIPTION
See Issue #111 

The artifact IDs for the spark-listeners and spark-listeners-loganalytics were specific spark and scala version numbers in some locations and were base artifact ids in other places. This caused issues when building the artifacts and then building the samples. 

This pull request makes the artifact ids consistent and fixes a dependency in the sample so that the artifacts are picked up properly from the .m2 directory. 

This pull request also updates the documentation with powershell examples of the windows commands to make it easier for users of powershell. 

@nextdynamic for visibility