### PR TITLE
Update sample job to not use variables in dependency artifactid

### DIFF
--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -108,7 +108,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.pnp</groupId>
-            <artifactId>spark-listeners_${spark.version}_${scala.compat.version}</artifactId>
+            <artifactId>spark-listeners</artifactId>
             <version>${spark.listeners.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
In #151 we updated the main project artifactId fields to not include variables.  This caused a dependency error if you build the sample on a machine that had not previously cached a version of the artifact that included the version string in the artifactId.  This update brings the dependency for the sample job into alignment with the generated artifacts.

Testing done: Full build of main project and sample jar with a clean Maven cache.

Supersedes: #153 