### PR TITLE
Support Spark 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ databricks runtime.
 | `7.3` - `7.6` | `scala-2.12_spark-3.0.1` |
 | `8.0` - `8.3` | `scala-2.12_spark-3.1.1` |
 | `8.4` - `9.1` | `scala-2.12_spark-3.1.2` |
+| `10.0` - `10.1` | `scala-2.12_spark-3.2.0` |
 
 1. Use Maven to build the POM located at `sample/spark-sample-job/pom.xml` or run the following Docker command:
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 echo 'hosts: files dns' > /etc/nsswitch.conf
 echo "127.0.0.1   $(hostname)" >> /etc/hosts
 
-MAVEN_PROFILES=( "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.5" "scala-2.12_spark-3.0.1" "scala-2.12_spark-3.1.1" "scala-2.12_spark-3.1.2")
+MAVEN_PROFILES=( "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.5" "scala-2.12_spark-3.0.1" "scala-2.12_spark-3.1.1" "scala-2.12_spark-3.1.2" "scala-2.12_spark-3.2.0")
 for MAVEN_PROFILE in "${MAVEN_PROFILES[@]}"
 do
     mvn -f /spark-monitoring/src/pom.xml install -P ${MAVEN_PROFILE}

--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -31,9 +31,6 @@
         </profile>
         <profile>
             <id>scala-2.12_spark-3.0.1</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <jetty.version>9.4.40.v20210413</jetty.version>
                 <slf4j.version>1.7.16</slf4j.version>
@@ -54,10 +51,23 @@
         </profile>
         <profile>
             <id>scala-2.12_spark-3.1.2</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <jetty.version>9.4.40.v20210413</jetty.version>
                 <slf4j.version>1.7.30</slf4j.version>
                 <spark.version>3.1.2</spark.version>
+                <scala.version>2.12.12</scala.version>
+                <scala.compat.version>2.12</scala.compat.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.12_spark-3.2.0</id>
+            <properties>
+                <jetty.version>9.4.40.v20210413</jetty.version>
+                <slf4j.version>1.7.30</slf4j.version>
+                <spark.version>3.2.0</spark.version>
                 <scala.version>2.12.12</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
             </properties>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -38,9 +38,6 @@
         </profile>
         <profile>
             <id>scala-2.12_spark-3.0.1</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <properties>
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
                 <jetty.version>9.4.40.v20210413</jetty.version>
@@ -63,10 +60,24 @@
         </profile>
         <profile>
             <id>scala-2.12_spark-3.1.2</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
                 <jetty.version>9.4.40.v20210413</jetty.version>
                 <spark.version>3.1.2</spark.version>
+                <scala.version>2.12.12</scala.version>
+                <scala.compat.version>2.12</scala.compat.version>
+                <scalatest.version>3.2.9</scalatest.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.12_spark-3.2.0</id>
+            <properties>
+                <commons.httpclient.version>4.5.13</commons.httpclient.version>
+                <jetty.version>9.4.40.v20210413</jetty.version>
+                <spark.version>3.2.0</spark.version>
                 <scala.version>2.12.12</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
                 <scalatest.version>3.2.9</scalatest.version>

--- a/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/metrics/sink/loganalytics/LogAnalyticsMetricsSink.scala
+++ b/src/spark-listeners-loganalytics/src/main/scala/org/apache/spark/metrics/sink/loganalytics/LogAnalyticsMetricsSink.scala
@@ -14,6 +14,15 @@ private class LogAnalyticsMetricsSink(
                                 securityMgr: SecurityManager)
   extends Sink with Logging {
 
+  // This additional constructor allows the library to be used on Spark 3.2.x clusters
+  // without the fix for https://issues.apache.org/jira/browse/SPARK-37078
+  def this(
+        property: Properties,
+        registry: MetricRegistry)
+  {
+    this(property, registry, null)
+  }
+
   private val config = new LogAnalyticsSinkConfiguration(property)
 
   org.apache.spark.metrics.MetricsSystem.checkMinimalPollingPeriod(config.pollUnit, config.pollPeriod)

--- a/src/spark-listeners/scripts/spark-monitoring.sh
+++ b/src/spark-listeners/scripts/spark-monitoring.sh
@@ -43,7 +43,7 @@ export AZ_RSRC_NAME=
 # Add a quoted regex value to filter the events for SparkLoggingEvent_CL, the log will only include events where logger_name_s matches the name regex
 # or where the Message matches the message regex.  If both are specified, then both must be matched for the log to be sent.
 # Commented examples below will only log messages where the logger name is com.microsoft.pnp.samplejob.StreamingQueryListenerSampleJob or begins with
-# org.apache.spark.util.Utils, or where the Message ends with the string `StreamingQueryListenerSampleJob` or begins with the string `FS_CONF_COMPAT`.
+# org.apache.spark.util.Utils, or where the Message ends with the string 'StreamingQueryListenerSampleJob' or begins with the string 'FS_CONF_COMPAT'.
 # export LA_SPARKLOGGINGEVENT_NAME_REGEX="com\.microsoft\.pnp\.samplejob\.StreamingQueryListenerSampleJob|org\.apache\.spark\.util\.Utils.*"
 # export LA_SPARKLOGGINGEVENT_MESSAGE_REGEX=".*StreamingQueryListenerSampleJob|FS_CONF_COMPAT.*"
 EOF

--- a/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
@@ -21,7 +21,7 @@ object LogAnalyticsStreamingQueryListenerSuite {
   val queryTerminatedEvent = new QueryTerminatedEvent(UUID.randomUUID, UUID.randomUUID, None)
   val queryProgressEvent = {
     // v3.0.1-: StateOperatorProgress: (numRowsTotal: Long, numRowsUpdated: Long, memoryUsedBytes: Long, customMetrics: java.util.Map[String,Long])
-    // v3.1.* : StateOperatorProgress: (numRowsTotal:                       Long, numRowsUpdated: Long, memoryUsedBytes: Long, numRowsDroppedByWatermark: Long, customMetrics: java.util.Map[String,Long])
+    // v3.1.* : StateOperatorProgress: (numRowsTotal: Long, numRowsUpdated: Long, memoryUsedBytes: Long, numRowsDroppedByWatermark: Long, customMetrics: java.util.Map[String,Long])
     // v3.2.0+: StateOperatorProgress: (operatorName: String, numRowsTotal: Long, numRowsUpdated: Long, allUpdatesTimeMs: Long, numRowsRemoved: Long, allRemovalsTimeMs: Long, commitTimeMs: Long, memoryUsedBytes: Long, numRowsDroppedByWatermark: Long, numShufflePartitions: Long, numStateStoreInstances: Long, customMetrics: java.util.Map[String,Long])
     val v30argsStateOperatorProgress = List[Any](0, 1, 2, new java.util.HashMap())
     val v31argsStateOperatorProgress = List[Any](0, 1, 2, 3, new java.util.HashMap())

--- a/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/sql/streaming/LogAnalyticsStreamingQueryListenerSuite.scala
@@ -20,14 +20,22 @@ object LogAnalyticsStreamingQueryListenerSuite {
 
   val queryTerminatedEvent = new QueryTerminatedEvent(UUID.randomUUID, UUID.randomUUID, None)
   val queryProgressEvent = {
-    // Note - this workaround will no longer be needed once versions before 3.1.1 are no longer supported
     // v3.0.1-: StateOperatorProgress: (numRowsTotal: Long, numRowsUpdated: Long, memoryUsedBytes: Long, customMetrics: java.util.Map[String,Long])
-    // v3.1.1+: StateOperatorProgress: (numRowsTotal: Long, numRowsUpdated: Long, memoryUsedBytes: Long, numRowsDroppedByWatermark: Long, customMetrics: java.util.Map[String,Long])
-    val v30args = List[Any](0, 1, 2, new java.util.HashMap())
-    val v31args = List[Any](0, 1, 2, 3, new java.util.HashMap())
-    val stateOperatorProgress = newInstance(classOf[StateOperatorProgress], v30args:_*)
-      .orElse(newInstance(classOf[StateOperatorProgress], v31args:_*))
+    // v3.1.* : StateOperatorProgress: (numRowsTotal:                       Long, numRowsUpdated: Long, memoryUsedBytes: Long, numRowsDroppedByWatermark: Long, customMetrics: java.util.Map[String,Long])
+    // v3.2.0+: StateOperatorProgress: (operatorName: String, numRowsTotal: Long, numRowsUpdated: Long, allUpdatesTimeMs: Long, numRowsRemoved: Long, allRemovalsTimeMs: Long, commitTimeMs: Long, memoryUsedBytes: Long, numRowsDroppedByWatermark: Long, numShufflePartitions: Long, numStateStoreInstances: Long, customMetrics: java.util.Map[String,Long])
+    val v30argsStateOperatorProgress = List[Any](0, 1, 2, new java.util.HashMap())
+    val v31argsStateOperatorProgress = List[Any](0, 1, 2, 3, new java.util.HashMap())
+    val v32argsStateOperatorProgress = List[Any]("operatorName", 0, 1, 10, 2, 10, 10, 3, 4, 5, 6, new java.util.HashMap())
+
+    val stateOperatorProgress = newInstance(classOf[StateOperatorProgress], v30argsStateOperatorProgress:_*)
+      .orElse(newInstance(classOf[StateOperatorProgress], v31argsStateOperatorProgress:_*))
+      .orElse(newInstance(classOf[StateOperatorProgress], v32argsStateOperatorProgress:_*))
       .get
+
+    // v3.1.2-: SourceProgress: (description: String, startOffset: String, endOffset: String, numInputRows: Long, inputRowsPerSecond: Double, processedRowsPerSecond: Double)
+    // v3.2.0+: SourceProgress: (description: String, startOffset: String, endOffset: String, latestOffset: String, numInputRows: Long, inputRowsPerSecond: Double, processedRowsPerSecond: Double, metrics: java.util.Map[String,String])
+    val v31argsSourceProgress = List[Any]("source", "123", "456", 678, Double.NaN, Double.NegativeInfinity)
+    val v32argsSourceProgress = List[Any]("source", "123", "456", "789", 1000, Double.NaN, Double.NegativeInfinity, new java.util.HashMap())
 
     val spark2args = List[Any](
       UUID.randomUUID,
@@ -39,14 +47,9 @@ object LogAnalyticsStreamingQueryListenerSuite {
       mapAsJavaMap(Map.empty[String, String]),
       Array(stateOperatorProgress),
       Array(
-        new SourceProgress(
-          "source",
-          "123",
-          "456",
-          678,
-          Double.NaN,
-          Double.NegativeInfinity
-        )
+        newInstance(classOf[SourceProgress], v31argsSourceProgress:_*)
+        .orElse(newInstance(classOf[SourceProgress], v32argsSourceProgress:_*))
+        .get
       ),
       new SinkProgress("sink")
     )


### PR DESCRIPTION
- Update spark-monitoring.sh script to eliminate errors from backtick characters being processed in here-string
- Add profile for Spark 3.2.0, update build.sh to include new profile
- Change tests for LogAnalyticsStreamingQueryListenerSuite to handle new constructor signatures for StateOperatorProgress and SourceProgress
- Add constructor for LogAnalyticsMetricsSink to avoid error from https://issues.apache.org/jira/browse/SPARK-37078 on Spark 3.2.0 clusters
- Update README.md to include profile for Spark 3.2.0

Fixes: #155 