### PR TITLE
Allow multiple Spark Context in test configuration

### DIFF
--- a/src/spark-listeners/src/test/scala/org/apache/spark/listeners/ListenerSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/listeners/ListenerSuite.scala
@@ -36,7 +36,8 @@ class ListenerSuite extends SparkFunSuite
     super.beforeEach()
     // We will use a mock sink
     val conf = new SparkConf()
-    conf.set("spark.unifiedListener.sink", classOf[TestSparkListenerSink].getName)
+        .set("spark.driver.allowMultipleContexts", "true")
+        .set("spark.unifiedListener.sink", classOf[TestSparkListenerSink].getName)
     this.logEventCaptor = ArgumentCaptor.forClass(classOf[Option[JValue]])
     this.listener = spy(new UnifiedSparkListener(conf))
   }

--- a/src/spark-listeners/src/test/scala/org/apache/spark/listeners/LogAnalyticsListenerSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/listeners/LogAnalyticsListenerSuite.scala
@@ -325,8 +325,9 @@ class LogAnalyticsListenerSuite extends ListenerSuite
 
   test("should not invoke onBlockUpdated when logBlockUpdates is set to false ") {
     val conf = new SparkConf()
-    conf.set("spark.unifiedListener.sink", classOf[TestSparkListenerSink].getName)
-    conf.set("spark.unifiedListener.logBlockUpdates", "false")
+        .set("spark.driver.allowMultipleContexts", "true")
+        .set("spark.unifiedListener.sink", classOf[TestSparkListenerSink].getName)
+        .set("spark.unifiedListener.logBlockUpdates", "false")
     this.listener = spy(new UnifiedSparkListener(conf))
     this.listener.onBlockUpdated(LogAnalyticsListenerSuite.sparkListenerBlockUpdated)
     verify(this.listener, times(0)).sendToSink(any(classOf[Option[JValue]]))
@@ -334,8 +335,9 @@ class LogAnalyticsListenerSuite extends ListenerSuite
 
   test("should invoke onBlockUpdated when logBlockUpdates is set to true ") {
     val conf = new SparkConf()
-    conf.set("spark.unifiedListener.sink", classOf[TestSparkListenerSink].getName)
-    conf.set("spark.unifiedListener.logBlockUpdates", "true")
+        .set("spark.driver.allowMultipleContexts", "true")
+        .set("spark.unifiedListener.sink", classOf[TestSparkListenerSink].getName)
+        .set("spark.unifiedListener.logBlockUpdates", "true")
     this.listener = spy(new UnifiedSparkListener(conf))
     this.onSparkListenerEvent(
       this.listener.onBlockUpdated,

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/CustomMetricsSystemSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/CustomMetricsSystemSuite.scala
@@ -54,6 +54,7 @@ class MetricsSystemsSuite extends SparkFunSuite
 
   override def afterEach(): Unit = {
     super.afterEach
+    sc=null
     env = null
     rpcEnv = null
   }

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricsSourceBuildersSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/MetricsSourceBuildersSuite.scala
@@ -151,6 +151,7 @@ class RemoteMetricsSourceBuilderSuite extends SparkFunSuite
       .setMaster("local[2]")
       .setAppName("test")
       .set("spark.dynamicAllocation.testing", "true")
+      .set("spark.driver.allowMultipleContexts", "true")
     env = mock(classOf[SparkEnv])
     rpcEnv = mock(classOf[RpcEnv])
     when(env.conf).thenReturn(conf)

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/ReceiverMetricSystemBuilderSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/ReceiverMetricSystemBuilderSuite.scala
@@ -26,6 +26,7 @@ class ReceiverMetricSystemBuilderSuite extends SparkFunSuite
       .setMaster("local[2]")
       .setAppName("test")
       .set("spark.dynamicAllocation.testing", "true")
+      .set("spark.driver.allowMultipleContexts", "true")
     env = mock(classOf[SparkEnv])
     rpcEnv = mock(classOf[RpcEnv])
     when(env.executorId).thenReturn(SparkContext.DRIVER_IDENTIFIER)

--- a/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
+++ b/src/spark-listeners/src/test/scala/org/apache/spark/metrics/RpcMetricsReceiverSuite.scala
@@ -108,6 +108,7 @@ class RpcMetricsReceiverSuite extends SparkFunSuite
     meter = null
     timer = null
     settableGauge = null
+    sc=null
   }
 
   test("getMetric returns valid metric") {


### PR DESCRIPTION
Address occasional test errors caused by SPARK-2243. Spark does not
allow multiple contexts in the same jvm, however the testing framework
for spark-monitoring creates and destroys Spark contexts through the
normal course of operation.  There is an occasional timing issue where
a previous context cleanup is not complete, triggering an error. This
change overrides the check for testing only.

This change does not address all possible ways to hit SPARK-2243 in tests
but should make it less likely.  If you receive an error message
referencing SPARK-2243 when building, perform the build again.