### PR TITLE
Add instrumentation logging to LogAnalyticsSendBufferTask and retry to LogAnalyticsClient

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,5 +7,5 @@ echo "127.0.0.1   $(hostname)" >> /etc/hosts
 MAVEN_PROFILES=( "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.5" "scala-2.12_spark-3.0.1" "scala-2.12_spark-3.1.1" "scala-2.12_spark-3.1.2" "scala-2.12_spark-3.2.0")
 for MAVEN_PROFILE in "${MAVEN_PROFILES[@]}"
 do
-    mvn -f /spark-monitoring/src/pom.xml install -P ${MAVEN_PROFILE}
+    mvn -f /spark-monitoring/src/pom.xml install -P ${MAVEN_PROFILE} "$@"
 done

--- a/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/client/loganalytics/LogAnalyticsClient.java
+++ b/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/client/loganalytics/LogAnalyticsClient.java
@@ -3,10 +3,12 @@ package com.microsoft.pnp.client.loganalytics;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -58,6 +60,8 @@ public class LogAnalyticsClient implements Closeable {
                 .disableAuthCaching()
                 .disableContentCompression()
                 .disableCookieManagement()
+                .setRetryHandler(new DefaultHttpRequestRetryHandler())
+                .setDefaultRequestConfig(RequestConfig.custom().setConnectTimeout(15000).setSocketTimeout(120000).build())
                 .build());
     }
 
@@ -97,6 +101,10 @@ public class LogAnalyticsClient implements Closeable {
         this.workspaceKey = workspaceKey;
         this.httpClient = httpClient;
         this.url = String.format(URL_FORMAT, this.workspaceId, urlSuffix, apiVersion);
+    }
+
+    public boolean ready() {
+        return(this.workspaceId != null && this.workspaceKey != null);
     }
 
     public void send(String body, String logType) throws IOException {

--- a/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/client/loganalytics/LogAnalyticsClient.java
+++ b/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/client/loganalytics/LogAnalyticsClient.java
@@ -9,6 +9,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -61,6 +62,7 @@ public class LogAnalyticsClient implements Closeable {
                 .disableContentCompression()
                 .disableCookieManagement()
                 .setRetryHandler(new DefaultHttpRequestRetryHandler())
+                .setServiceUnavailableRetryStrategy(new DefaultServiceUnavailableRetryStrategy(3,1000))
                 .setDefaultRequestConfig(RequestConfig.custom().setConnectTimeout(15000).setSocketTimeout(120000).build())
                 .build());
     }

--- a/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/client/loganalytics/LogAnalyticsSendBufferTask.java
+++ b/src/spark-listeners-loganalytics/src/main/java/com/microsoft/pnp/client/loganalytics/LogAnalyticsSendBufferTask.java
@@ -2,6 +2,8 @@ package com.microsoft.pnp.client.loganalytics;
 
 import com.microsoft.pnp.client.GenericSendBufferTask;
 
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import java.util.List;
 
 public class LogAnalyticsSendBufferTask extends GenericSendBufferTask<String> {
@@ -46,11 +48,31 @@ public class LogAnalyticsSendBufferTask extends GenericSendBufferTask<String> {
         }
         sb.deleteCharAt(sb.lastIndexOf(",")).append("]");
         try {
+            int retry=8;
+            int backoff=1;
+            while(!client.ready() && retry-- > 0){
+                System.err.println("Log Analytics client not ready, waiting: " + backoff + " seconds at time = " + Instant.now());
+                TimeUnit.SECONDS.sleep(backoff);
+                backoff*=2;
+            }
             client.send(sb.toString(), logType, timeGeneratedField);
         } catch (Exception ioe) {
             // We can't do much here since we might be inside a logger
-            System.err.println(ioe.getMessage());
-            System.err.println(ioe);
+            ioe.printStackTrace();
+            Throwable inner = ioe.getCause();
+            while(inner != null) {
+                System.err.println("Details of nested cause:");
+                inner.printStackTrace();
+                inner=inner.getCause();
+            }
+            System.err.println("Buffer causing error on send(body, logType, timestampFieldName):");
+            System.err.println("clock time = " + Instant.now());
+            System.err.println("logType = " + logType);
+            System.err.println("timestampFieldName = " + timeGeneratedField);
+            if(System.getenv().getOrDefault("LA_LOGFAILEDBUFFERSEND", "") == "TRUE") {
+                System.err.println("body =");
+                System.err.println(sb.toString());
+            }
         }
     }
 }

--- a/src/spark-listeners/scripts/spark-monitoring.sh
+++ b/src/spark-listeners/scripts/spark-monitoring.sh
@@ -46,6 +46,9 @@ export AZ_RSRC_NAME=
 # org.apache.spark.util.Utils, or where the Message ends with the string 'StreamingQueryListenerSampleJob' or begins with the string 'FS_CONF_COMPAT'.
 # export LA_SPARKLOGGINGEVENT_NAME_REGEX="com\.microsoft\.pnp\.samplejob\.StreamingQueryListenerSampleJob|org\.apache\.spark\.util\.Utils.*"
 # export LA_SPARKLOGGINGEVENT_MESSAGE_REGEX=".*StreamingQueryListenerSampleJob|FS_CONF_COMPAT.*"
+
+# Uncomment the following line to enable local logging to stderr of buffer contents when an exception is hit when sending a buffer to Log Analytics
+# export LA_LOGFAILEDBUFFERSEND=TRUE
 EOF
 
 STAGE_DIR=/dbfs/databricks/spark-monitoring

--- a/src/spark-listeners/src/main/java/com/microsoft/pnp/client/GenericSendBuffer.java
+++ b/src/spark-listeners/src/main/java/com/microsoft/pnp/client/GenericSendBuffer.java
@@ -46,7 +46,7 @@ public abstract class GenericSendBuffer<T> implements AutoCloseable {
     private final Semaphore inflightBatches;
 
     // Make configurable
-    private final int maxInflightBatches = 1;
+    private final int maxInflightBatches = 4;
 
     protected GenericSendBuffer() {
         this.inflightBatches = new Semaphore(this.maxInflightBatches);

--- a/src/spark-listeners/src/main/java/com/microsoft/pnp/client/GenericSendBuffer.java
+++ b/src/spark-listeners/src/main/java/com/microsoft/pnp/client/GenericSendBuffer.java
@@ -91,6 +91,8 @@ public abstract class GenericSendBuffer<T> implements AutoCloseable {
                         this.sendBufferTask.getMaxBatchSizeBytes());
                         System.err.println(message);
                         if(EXCEPTION_ON_FAILED_SEND) {
+                            // If we are throwing before we call execute on the sendBufferTask, we should release the semaphore.
+                            inflightBatches.release();
                             throw new RuntimeException(message);
                         }
                     }


### PR DESCRIPTION
Finding the cause of errors sending data to Log Analytics has been challenging. This change adds additional instrumentation and exception cause logging for errors occurring in LogAnalyticsClient.send(...).  Additionally, a default retry policy (3 retries) is added to the HttpClient that is used by LogAnalyticsClient, as well as an extended default timeout policy.