### PR TITLE
Version support updates Jan 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,10 @@ databricks runtime.
 
 | Databricks Runtime(s) | Maven Profile |
 | -- | -- |
-| `5.5` | `scala-2.11_spark-2.4.3` |
-| `6.4` | `scala-2.11_spark-2.4.5` |
-| `7.3` - `7.6` | `scala-2.12_spark-3.0.1` |
-| `8.0` - `8.3` | `scala-2.12_spark-3.1.1` |
-| `8.4` - `9.1` | `scala-2.12_spark-3.1.2` |
-| `10.0` - `10.1` | `scala-2.12_spark-3.2.0` |
+| `6.4 Extended Support` | `scala-2.11_spark-2.4.5` |
+| `7.3 LTS` | `scala-2.12_spark-3.0.1` |
+| `9.0` - `9.1 LTS` | `scala-2.12_spark-3.1.2` |
+| `10.0` - `10.2` | `scala-2.12_spark-3.2.0` |
 
 1. Use Maven to build the POM located at `sample/spark-sample-job/pom.xml` or run the following Docker command:
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 echo 'hosts: files dns' > /etc/nsswitch.conf
 echo "127.0.0.1   $(hostname)" >> /etc/hosts
 
-MAVEN_PROFILES=( "scala-2.11_spark-2.4.3" "scala-2.11_spark-2.4.5" "scala-2.12_spark-3.0.1" "scala-2.12_spark-3.1.1" "scala-2.12_spark-3.1.2" "scala-2.12_spark-3.2.0")
+MAVEN_PROFILES=( "scala-2.11_spark-2.4.5" "scala-2.12_spark-3.0.1" "scala-2.12_spark-3.1.2" "scala-2.12_spark-3.2.0")
 for MAVEN_PROFILE in "${MAVEN_PROFILES[@]}"
 do
     mvn -f /spark-monitoring/src/pom.xml install -P ${MAVEN_PROFILE}

--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -10,20 +10,10 @@
 
     <profiles>
         <profile>
-            <id>scala-2.11_spark-2.4.3</id>
-            <properties>
-                <jetty.version>9.4.40.v20210413</jetty.version>
-                <slf4j.version>1.7.16</slf4j.version>
-                <spark.version>2.4.3</spark.version>
-                <scala.version>2.11.12</scala.version>
-                <scala.compat.version>2.11</scala.compat.version>
-            </properties>
-        </profile>
-        <profile>
             <id>scala-2.11_spark-2.4.5</id>
             <properties>
-                <jetty.version>9.4.40.v20210413</jetty.version>
-                <slf4j.version>1.7.16</slf4j.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
+                <slf4j.version>1.7.30</slf4j.version>
                 <spark.version>2.4.5</spark.version>
                 <scala.version>2.11.12</scala.version>
                 <scala.compat.version>2.11</scala.compat.version>
@@ -32,20 +22,10 @@
         <profile>
             <id>scala-2.12_spark-3.0.1</id>
             <properties>
-                <jetty.version>9.4.40.v20210413</jetty.version>
-                <slf4j.version>1.7.16</slf4j.version>
-                <spark.version>3.0.1</spark.version>
-                <scala.version>2.12.12</scala.version>
-                <scala.compat.version>2.12</scala.compat.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>scala-2.12_spark-3.1.1</id>
-            <properties>
-                <jetty.version>9.4.40.v20210413</jetty.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
                 <slf4j.version>1.7.30</slf4j.version>
-                <spark.version>3.1.1</spark.version>
-                <scala.version>2.12.12</scala.version>
+                <spark.version>3.0.1</spark.version>
+                <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
             </properties>
         </profile>
@@ -55,20 +35,20 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <jetty.version>9.4.40.v20210413</jetty.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
                 <slf4j.version>1.7.30</slf4j.version>
                 <spark.version>3.1.2</spark.version>
-                <scala.version>2.12.12</scala.version>
+                <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
             </properties>
         </profile>
         <profile>
             <id>scala-2.12_spark-3.2.0</id>
             <properties>
-                <jetty.version>9.4.40.v20210413</jetty.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
                 <slf4j.version>1.7.30</slf4j.version>
                 <spark.version>3.2.0</spark.version>
-                <scala.version>2.12.12</scala.version>
+                <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
             </properties>
         </profile>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -15,21 +15,10 @@
 
     <profiles>
         <profile>
-            <id>scala-2.11_spark-2.4.3</id>
-            <properties>
-                <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.40.v20210413</jetty.version>
-                <spark.version>2.4.3</spark.version>
-                <scala.version>2.11.12</scala.version>
-                <scala.compat.version>2.11</scala.compat.version>
-                <scalatest.version>3.0.9</scalatest.version>
-            </properties>
-        </profile>
-        <profile>
             <id>scala-2.11_spark-2.4.5</id>
             <properties>
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.40.v20210413</jetty.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
                 <spark.version>2.4.5</spark.version>
                 <scala.version>2.11.12</scala.version>
                 <scala.compat.version>2.11</scala.compat.version>
@@ -40,22 +29,11 @@
             <id>scala-2.12_spark-3.0.1</id>
             <properties>
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.40.v20210413</jetty.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
                 <spark.version>3.0.1</spark.version>
-                <scala.version>2.12.12</scala.version>
+                <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
                 <scalatest.version>3.0.9</scalatest.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>scala-2.12_spark-3.1.1</id>
-            <properties>
-                <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.40.v20210413</jetty.version>
-                <spark.version>3.1.1</spark.version>
-                <scala.version>2.12.12</scala.version>
-                <scala.compat.version>2.12</scala.compat.version>
-                <scalatest.version>3.2.9</scalatest.version>
             </properties>
         </profile>
         <profile>
@@ -65,9 +43,9 @@
             </activation>
             <properties>
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.40.v20210413</jetty.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
                 <spark.version>3.1.2</spark.version>
-                <scala.version>2.12.12</scala.version>
+                <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
                 <scalatest.version>3.2.9</scalatest.version>
             </properties>
@@ -76,9 +54,9 @@
             <id>scala-2.12_spark-3.2.0</id>
             <properties>
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.40.v20210413</jetty.version>
+                <jetty.version>9.4.44.v20210927</jetty.version>
                 <spark.version>3.2.0</spark.version>
-                <scala.version>2.12.12</scala.version>
+                <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
                 <scalatest.version>3.2.9</scalatest.version>
             </properties>


### PR DESCRIPTION
- Remove versions no longer supported per https://docs.microsoft.com/azure/databricks/release-notes/runtime/releases from README and build.sh
- Update jetty to latest 9.4 version
- Update slf4j to latest 1.7 version for all profiles
- Update scala 2.12 profiles to 2.12.14