### PR TITLE
Version Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,17 @@ Before you begin, ensure you have the following prerequisites in place:
   * You can also use the Azure Databricks CLI from the Azure Cloud Shell.
 * A Java IDE, with the following resources:
   * [Java Devlopment Kit (JDK) version 1.8](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
-  * [Scala language SDK 2.11 and/or 2.12](https://www.scala-lang.org/download/)
+  * [Scala language SDK 2.12](https://www.scala-lang.org/download/)
   * [Apache Maven 3.6.3](https://maven.apache.org/download.html)
 
 ### Supported configurations
 
 | Databricks Runtime(s) | Maven Profile |
 | -- | -- |
-| `6.4 Extended Support` | `scala-2.11_spark-2.4.5` |
 | `7.3 LTS` | `scala-2.12_spark-3.0.1` |
 | `9.1 LTS` | `scala-2.12_spark-3.1.2` |
-| `10.1` - `10.2` | `scala-2.12_spark-3.2.0` |
 | `10.3` - `10.5` | `scala-2.12_spark-3.2.1` |
+| `11.0` | Not currently supported due to changes in [Log4j version](https://docs.microsoft.com/azure/databricks/release-notes/runtime/11.0#log4j-is-upgraded-from-log4j-1-to-log4j-2) |
 
 ## Logging Event Size Limit
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 echo 'hosts: files dns' > /etc/nsswitch.conf
 echo "127.0.0.1   $(hostname)" >> /etc/hosts
 
-MAVEN_PROFILES=( "scala-2.11_spark-2.4.5" "scala-2.12_spark-3.0.1" "scala-2.12_spark-3.1.2" "scala-2.12_spark-3.2.0" "scala-2.12_spark-3.2.1")
+MAVEN_PROFILES=( "scala-2.12_spark-3.0.1" "scala-2.12_spark-3.1.2" "scala-2.12_spark-3.2.1" )
 for MAVEN_PROFILE in "${MAVEN_PROFILES[@]}"
 do
     mvn -f /spark-monitoring/src/pom.xml install -P ${MAVEN_PROFILE} "$@"

--- a/sample/spark-sample-job/pom.xml
+++ b/sample/spark-sample-job/pom.xml
@@ -10,16 +10,6 @@
 
     <profiles>
         <profile>
-            <id>scala-2.11_spark-2.4.5</id>
-            <properties>
-                <jetty.version>9.4.44.v20210927</jetty.version>
-                <slf4j.version>1.7.30</slf4j.version>
-                <spark.version>2.4.5</spark.version>
-                <scala.version>2.11.12</scala.version>
-                <scala.compat.version>2.11</scala.compat.version>
-            </properties>
-        </profile>
-        <profile>
             <id>scala-2.12_spark-3.0.1</id>
             <properties>
                 <jetty.version>9.4.44.v20210927</jetty.version>
@@ -35,16 +25,6 @@
                 <jetty.version>9.4.44.v20210927</jetty.version>
                 <slf4j.version>1.7.30</slf4j.version>
                 <spark.version>3.1.2</spark.version>
-                <scala.version>2.12.14</scala.version>
-                <scala.compat.version>2.12</scala.compat.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>scala-2.12_spark-3.2.0</id>
-            <properties>
-                <jetty.version>9.4.44.v20210927</jetty.version>
-                <slf4j.version>1.7.30</slf4j.version>
-                <spark.version>3.2.0</spark.version>
                 <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
             </properties>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -15,17 +15,6 @@
 
     <profiles>
         <profile>
-            <id>scala-2.11_spark-2.4.5</id>
-            <properties>
-                <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.44.v20210927</jetty.version>
-                <spark.version>2.4.5</spark.version>
-                <scala.version>2.11.12</scala.version>
-                <scala.compat.version>2.11</scala.compat.version>
-                <scalatest.version>3.0.9</scalatest.version>
-            </properties>
-        </profile>
-        <profile>
             <id>scala-2.12_spark-3.0.1</id>
             <properties>
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
@@ -42,17 +31,6 @@
                 <commons.httpclient.version>4.5.13</commons.httpclient.version>
                 <jetty.version>9.4.44.v20210927</jetty.version>
                 <spark.version>3.1.2</spark.version>
-                <scala.version>2.12.14</scala.version>
-                <scala.compat.version>2.12</scala.compat.version>
-                <scalatest.version>3.2.9</scalatest.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>scala-2.12_spark-3.2.0</id>
-            <properties>
-                <commons.httpclient.version>4.5.13</commons.httpclient.version>
-                <jetty.version>9.4.44.v20210927</jetty.version>
-                <spark.version>3.2.0</spark.version>
                 <scala.version>2.12.14</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
                 <scalatest.version>3.2.9</scalatest.version>


### PR DESCRIPTION
- Remove support for Spark 2.x, 3.2.0

Align supported versions with https://docs.microsoft.com/azure/databricks/release-notes/runtime/releases