### PR TITLE
Add newline option to JSONLayout

### DIFF
--- a/src/spark-listeners/src/main/java/com/microsoft/pnp/logging/JSONLayout.java
+++ b/src/spark-listeners/src/main/java/com/microsoft/pnp/logging/JSONLayout.java
@@ -16,6 +16,7 @@ public class JSONLayout extends Layout {
 
     public static final String TIMESTAMP_FIELD_NAME = "timestamp";
     private boolean locationInfo;
+    private boolean oneLogEventPerLine;
     private String jsonConfiguration;
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -84,7 +85,11 @@ public class JSONLayout extends Layout {
         }
 
         try {
-            return objectMapper.writeValueAsString(event);
+            if (oneLogEventPerLine) {
+                return objectMapper.writeValueAsString(event) + '\n';
+            } else {
+                return objectMapper.writeValueAsString(event);
+            }
         } catch (Exception ex) {
             LogLog.warn("Error serializing event", ex);
             return null;
@@ -106,6 +111,14 @@ public class JSONLayout extends Layout {
 
     public void setLocationInfo(boolean locationInfo) {
         this.locationInfo = locationInfo;
+    }
+
+    public boolean isOneLogEventPerLine() {
+        return oneLogEventPerLine;
+    }
+
+    public void setOneLogEventPerLine(boolean oneLogEventPerLine) {
+        this.oneLogEventPerLine = oneLogEventPerLine;
     }
 
     public String getJsonConfiguration() {

--- a/src/spark-listeners/src/test/scala/com/microsoft/pnp/logging/JSONLayoutTest.java
+++ b/src/spark-listeners/src/test/scala/com/microsoft/pnp/logging/JSONLayoutTest.java
@@ -1,0 +1,38 @@
+package com.microsoft.pnp.logging;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.Priority;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JSONLayoutTest {
+    private JSONLayout jsonLayout;
+
+    @Before
+    public void beforeEach() {
+        jsonLayout = new JSONLayout();
+    }
+
+    @Test
+    public void shouldSerializeWithoutTrainingNewline() {
+        jsonLayout.setOneLogEventPerLine(false);
+
+        assertFalse(jsonLayout.format(loggingEvent()).endsWith("\n"));
+    }
+
+    @Test
+    public void shouldSerializeWithTrainingNewline() {
+        jsonLayout.setOneLogEventPerLine(true);
+
+        assertTrue(jsonLayout.format(loggingEvent()).endsWith("\n"));
+    }
+
+    private LoggingEvent loggingEvent() {
+        return new LoggingEvent("info", Logger.getLogger("name"), Priority.INFO, "message", null);
+    }
+
+}


### PR DESCRIPTION
PR related to issue https://github.com/mspnp/spark-monitoring/issues/191:

>Hi all,
>
>We use spark-monitoring in our Databricks workspaces, but in a slightly non-standard way:
>
>Metrics are collected and pushed to Log Analytics, as per project design;
>Logs, on the other side, follow a different route: we want them formatted in JSON, but they are written to a shared storage >(due to our overall enterprise architecture) and then eventually exported to our logging backend.
>For this reason, we only need the `JSONLayout` piece of spark-monitoring when it comes to logs. We can do this by setting
>
>```
>log4j.appender.publicFile.layout=com.microsoft.pnp.logging.JSONLayout
>```
>in `log4j.properties`, but we have an additional requirement on JSONLayout: it must be configurable to add a newline at >the end of the serialised string because the software which parses our logs expects one logging even per line.
>
>We added a `OneLogEventPerLine property` to JSONLayout in our private fork of the project, it's a simple change and it's >working well. Would you be interested in porting this to your project?