### PR TITLE
remove single quotes from EOF

### DIFF
--- a/src/scripts/spark-monitoring.sh
+++ b/src/scripts/spark-monitoring.sh
@@ -12,7 +12,7 @@ DB_HOME=/databricks
 SPARK_HOME=$DB_HOME/spark
 SPARK_CONF_DIR=$SPARK_HOME/conf
 
-cat << 'EOF' >> "$SPARK_CONF_DIR/spark-env.sh"
+cat << EOF >> "$SPARK_CONF_DIR/spark-env.sh"
 
 export DB_CLUSTER_ID=$DB_CLUSTER_ID
 export DB_CLUSTER_NAME=$DB_CLUSTER_NAME


### PR DESCRIPTION
With the single quotes, this portion of the `spark-monitoring.sh` script doesn't function correctly.

You can determine this by printing out all of the available environment variables from inside the spark job.

For example, `DB_CLUSTER_ID` and `DB_CLUSTER_NAME` will be blank.
![image](https://github.com/mspnp/spark-monitoring/assets/81192343/6fe30be9-967c-4c14-9e7d-306f92f41124)
![image](https://github.com/mspnp/spark-monitoring/assets/81192343/bdaab00a-2548-4edb-95c3-829da4799a17)

After removing the single quotes those variables are available inside the spark job.
![image](https://github.com/mspnp/spark-monitoring/assets/81192343/9ae7abc2-789f-4f7b-8535-8f5ea1586470)
![image](https://github.com/mspnp/spark-monitoring/assets/81192343/aa64ef71-c714-49dd-948b-75c88efa03aa)
