### PR TITLE
Update README for DBR 13.3 and init scripts from volume or workspace

### DIFF
--- a/src/scripts/spark-monitoring.sh
+++ b/src/scripts/spark-monitoring.sh
@@ -28,7 +28,7 @@ EOF
 STAGE_DIR=/dbfs/databricks/spark-monitoring
 SPARK_MONITORING_VERSION=${SPARK_MONITORING_VERSION:-1.0.0}
 SPARK_VERSION=$(cat /databricks/spark/VERSION 2> /dev/null || echo "")
-SPARK_VERSION=${SPARK_VERSION:-3.3.1}
+SPARK_VERSION=${SPARK_VERSION:-3.4.1}
 SPARK_SCALA_VERSION=$(ls /databricks/spark/assembly/target | cut -d '-' -f2 2> /dev/null || echo "")
 SPARK_SCALA_VERSION=${SPARK_SCALA_VERSION:-2.12}
 


### PR DESCRIPTION
- Update README to reference 13.3 LTS and correct profile names
- Update README to point to using Workspace or Volume as source for the init script since DBFS is deprecated.
- Update README to use new Databricks CLI syntax and authentication.
- Updated doc links to use use learn.microsoft.com.
- Update spark-monitoring.sh default Spark version to 3.4.1 to fit 13.3 version.