### PR TITLE
[LogAnalyticsReporter] Fix stop method

### DIFF
--- a/src/main/scala/org/apache/spark/metrics/pnp/LogAnalyticsReporter.scala
+++ b/src/main/scala/org/apache/spark/metrics/pnp/LogAnalyticsReporter.scala
@@ -211,6 +211,11 @@ class LogAnalyticsReporter(val registry: MetricRegistry, val workspaceId: String
     }
   }
 
+  override def stop(): Unit = {
+    super.stop()
+    logAnalyticsBufferedClient.close()
+  }
+
   //private def addProperties(name: String, metric: Metric, timestamp: Instant): JValue = {
   private def addProperties(name: String, metric: Metric, properties: Map[String, String]): JValue = {
     val metricType: String = metric match {


### PR DESCRIPTION
# Context

`GenericSendBuffer` defined its own executor which needs to be closed at the end of application. Considering current implementation of `LogAnalyticsReporter`, it inherits `stop` method from `ScheduledReporter`. But it does not properly close `logAnalyticsBufferedClient`, which end up not losing   `GenericSendBuffer`s executor.
It might lead to problems where some metrics are not pushed to Log Analytics at the end of application, as `GenericSendBufferTask` defined [deadlineMs](https://github.com/mspnp/spark-monitoring/blob/l4jv2/src/main/java/com/microsoft/pnp/client/GenericSendBufferTask.java#L133) (currently is 5 seconds) and can be not ready by time when main thread is down.