### PR TITLE
LogAnalyticsReporter fix gauges retain

### DIFF
--- a/src/main/scala/org/apache/spark/metrics/pnp/LogAnalyticsReporter.scala
+++ b/src/main/scala/org/apache/spark/metrics/pnp/LogAnalyticsReporter.scala
@@ -195,7 +195,7 @@ class LogAnalyticsReporter(val registry: MetricRegistry, val workspaceId: String
     import scala.collection.JavaConversions._
 
     val ambientProperties = SparkInformation.get() + ("SparkEventTime" -> now.toString)
-    val metrics = gauges.retain((_, v) => v.getValue != null).toSeq ++
+    val metrics = gauges.filter { case (_, v) => v.getValue != null }.toSeq ++
       counters.toSeq ++ histograms.toSeq ++ meters.toSeq ++ timers.toSeq
     for ((name, metric) <- metrics) {
       try {


### PR DESCRIPTION
# Context: 

`gauges.retain((_, v) => v.getValue != null)` will run `MapLike.retain` method which would remove key from provided map, when condition is not met. This will cause an issue, when provided `java.util.SortedMap` is `UnmodifiableMap`, which would fail execution with `java.lang.UnsupportedOperationException`:
```
at java.util.Collections$UnmodifiableMap.remove(Collections.java:1462)
at scala.collection.convert.Wrappers$JMapWrapperLike.$minus$eq(Wrappers.scala:290)
at scala.collection.convert.Wrappers$JMapWrapperLike.$minus$eq$(Wrappers.scala:290)
at scala.collection.convert.Wrappers$JMapWrapper.$minus$eq(Wrappers.scala:317)
at scala.collection.convert.Wrappers$JMapWrapper.$minus$eq(Wrappers.scala:317)
at scala.collection.mutable.MapLike.$anonfun$retain$2(MapLike.scala:233)
at scala.collection.TraversableLike$WithFilter.$anonfun$foreach$1(TraversableLike.scala:985)
at scala.collection.immutable.List.foreach(List.scala:431)
at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:984)
at scala.collection.mutable.MapLike.retain(MapLike.scala:232)
at scala.collection.mutable.MapLike.retain$(MapLike.scala:231)
at scala.collection.mutable.AbstractMap.retain(Map.scala:85)
```

# Provided changes

Instead of retain, filter can be used, which would return new `mutalbe.Map` to void above exception.