### PR TITLE
Adding back support for LA_SPARKLOGGINGEVENT_NAME_REGEX

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -79,14 +79,34 @@ SparkMetric_CL
 
 ## Limiting Logs in SparkLoggingEvent_CL (Basic)
 
-The logs that propagate to SparkLoggingEvent_CL do so through a log4j appender.  This can be configured by altering the spark-monitoring.sh script that is responsible for writing the log4j.properties file. The script at [spark-monitoring.sh](../src/spark-listeners/scripts/spark-monitoring.sh) can be modified to set the threshold for events to be forwarded.  A commented example is included in the script.
+The logs that propagate to SparkLoggingEvent_CL do so through a log4j2 appender.
+This can be configured by altering the spark-monitoring.sh script that is responsible for writing the log4j2.xml file.
+The script at [spark-monitoring.sh](../src/scripts/spark-monitoring.sh) can be modified to set the threshold for events to be forwarded.
+A commented example is included in the script.
 
-```bash
-# Commented line below shows how to set the threshhold for logging to only capture events that are
-# level ERROR or more severe.
-# log4j.appender.logAnalyticsAppender.Threshold=ERROR
+```xml
+        <!-- Commented line below shows how to restrict the logs pushed to Log Analytics to ERROR level or more severe. -->
+        <!-- <ThresholdFilter level="ERROR" /> -->
 ```
 
+## Limiting Logs in SparkLoggingEvent_CL (Advanced)
+
+You can use the `LA_SPARKLOGGINGEVENT_NAME_REGEX` environment variable
+which is used in [spark-monitoring.sh](../src/scripts/spark-monitoring.sh) to update the log4j2.xml configuration 
+to limit the logging to only include events where `logger_name_s` matches the regex.
+
+The example below will only log events from logger `com.microsoft.pnp.samplejob.StreamingQueryListenerSampleJob`
+or where the logger name starts with `org.apache.spark.util.Utils`.
+
+`export LA_SPARKLOGGINGEVENT_NAME_REGEX="com\.microsoft\.pnp\.samplejob\.StreamingQueryListenerSampleJob|org\.apache\.spark\.util\.Utils.*"`
+
+You can use the `LA_SPARKLOGGINGEVENT_MESSAGE_REGEX` environment variable
+that is used in [spark-monitoring.sh](../src/scripts/spark-monitoring.sh) to update the log4j2.xml configuration 
+to limit the logging to only include events where the message matches the regex.
+
+The example below will only log events where the message begins with the string `FS_CONF_COMPAT`.
+
+`export LA_SPARKLOGGINGEVENT_MESSAGE_REGEX="FS_CONF_COMPAT.*"`
 
 ## Performance Considerations
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
                 <spark.version>3.3.0</spark.version>
                 <scala.version>2.12.15</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
+                <log4j.version>2.18.0</log4j.version>
             </properties>
         </profile>
         <profile>
@@ -29,6 +30,7 @@
                 <spark.version>3.3.2</spark.version>
                 <scala.version>2.12.15</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
+                <log4j.version>2.18.0</log4j.version>
             </properties>
         </profile>
         <profile>
@@ -42,6 +44,7 @@
                 <spark.version>3.4.1</spark.version>
                 <scala.version>2.12.15</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
+                <log4j.version>2.19.0</log4j.version>
             </properties>
         </profile>
         <profile>
@@ -55,6 +58,7 @@
                 <spark.version>3.5.0</spark.version>
                 <scala.version>2.12.18</scala.version>
                 <scala.compat.version>2.12</scala.compat.version>
+                <log4j.version>2.20.0</log4j.version>
             </properties>
         </profile>
     </profiles>
@@ -145,6 +149,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core-test</artifactId>
+                <version>${log4j.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/src/main/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilter.java
+++ b/src/main/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilter.java
@@ -1,0 +1,84 @@
+package com.microsoft.pnp.logging.loganalytics;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.message.Message;
+
+import java.util.regex.Pattern;
+
+/**
+ * This custom filter is used to filter log events based on the logger name.
+ * It is designed to be used only at appender level.
+ * The "regex" attribute is used to specify the regular expression to match the entire logger name.
+ *
+ */
+@Plugin(name = "LoggerNameFilter",
+    category = Node.CATEGORY,
+    elementType = Filter.ELEMENT_TYPE,
+    printObject = true)
+public class LoggerNameFilter extends AbstractFilter {
+
+  private final Pattern pattern;
+
+  private LoggerNameFilter(final Pattern pattern, final Result onMatch, final Result onMismatch) {
+    super(onMatch, onMismatch);
+    this.pattern = pattern;
+  }
+
+  @Override
+  public Result filter(LogEvent event) {
+    return filter(event.getLoggerName());
+  }
+
+  @Override
+  public Result filter(Logger logger, Level level, Marker marker, Message msg, Throwable t) {
+    return filter(logger.getName());
+  }
+
+  @Override
+  public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
+    return filter(logger.getName());
+  }
+
+  @Override
+  public Result filter(Logger logger, Level level, Marker marker, String msg, Object... params) {
+    return filter(logger.getName());
+  }
+
+  private Result filter(final String loggerName) {
+    if (loggerName != null && pattern.matcher(loggerName).matches()) {
+      return onMatch;
+    }
+    return onMismatch;
+  }
+
+  @PluginBuilderFactory
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder extends AbstractFilterBuilder<Builder>
+      implements org.apache.logging.log4j.core.util.Builder<LoggerNameFilter> {
+
+      @PluginBuilderAttribute
+      private String regex;
+
+      public Builder setRegex(String regex) {
+        this.regex = regex;
+        return this;
+      }
+
+      @Override
+      public LoggerNameFilter build() throws IllegalArgumentException{
+        return new LoggerNameFilter(Pattern.compile(regex), getOnMatch(), getOnMismatch());
+      }
+  }
+}

--- a/src/main/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilter.java
+++ b/src/main/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilter.java
@@ -6,13 +6,14 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
-import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.message.Message;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * This custom filter is used to filter log events based on the logger name.
@@ -78,7 +79,17 @@ public class LoggerNameFilter extends AbstractFilter {
 
       @Override
       public LoggerNameFilter build() throws IllegalArgumentException{
-        return new LoggerNameFilter(Pattern.compile(regex), getOnMatch(), getOnMismatch());
+          if (regex == null) {
+              LOGGER.warn("LoggerNameFilter regex has been defaulted to .*");
+              regex = ".*";
+          }
+          try {
+              return new LoggerNameFilter(Pattern.compile(regex), getOnMatch(), getOnMismatch());
+          } catch (PatternSyntaxException pse) {
+              String message = "Could not compile the LoggerNameFilter regex : " + pse.getMessage();
+              LOGGER.error(message);
+              throw new IllegalArgumentException(message);
+          }
       }
   }
 }

--- a/src/test/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilterPassesNoRegexpTest.java
+++ b/src/test/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilterPassesNoRegexpTest.java
@@ -1,0 +1,44 @@
+package com.microsoft.pnp.logging.loganalytics;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@LoggerContextSource("log4j-loggernamefilter-noregexp.xml")
+public class LoggerNameFilterPassesNoRegexpTest {
+
+    private final ListAppender appender;
+    private final LoggerNameFilter filter;
+    private final Logger matchingLogger;
+    private final Logger nonMatchingLogger;
+
+    public LoggerNameFilterPassesNoRegexpTest(final LoggerContext context, @Named("LIST") final ListAppender app) {
+        this.appender = app;
+        this.filter = (LoggerNameFilter) app.getFilter();
+        this.matchingLogger = context.getLogger(getClass());
+        this.nonMatchingLogger = context.getLogger("com.not.matching.logger");
+    }
+
+    /**
+     * Test the case where the logger name matches the regex provided to the filter
+     * and the one where it does not.
+     */
+    @Test
+    public void testAbsenceOfRegex() {
+        assertNotNull(filter);
+        assertInstanceOf(LoggerNameFilter.class, filter);
+        matchingLogger.info("This log message should be accepted by the filter.");
+        // The appender should have only received the log message from the matching logger.
+        assertEquals(1, appender.getMessages().size());
+        appender.clear();
+        nonMatchingLogger.info("This log message should be accepted by the filter as week.");
+        assertEquals(1, appender.getMessages().size());
+    }
+
+}

--- a/src/test/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilterTest.java
+++ b/src/test/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilterTest.java
@@ -1,0 +1,46 @@
+package com.microsoft.pnp.logging.loganalytics;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+
+
+@LoggerContextSource("log4j-loggernamefilter.xml")
+public class LoggerNameFilterTest {
+
+  private final ListAppender appender;
+  private final LoggerNameFilter filter;
+  private final Logger matchingLogger;
+  private final Logger nonMatchingLogger;
+
+  public LoggerNameFilterTest(final LoggerContext context, @Named("LIST") final ListAppender app) {
+    this.appender = app;
+    this.filter = (LoggerNameFilter)app.getFilter();
+    this.matchingLogger = context.getLogger(getClass());
+    this.nonMatchingLogger = context.getLogger("com.not.matching.logger");
+  }
+
+  /**
+   * Test the case where the logger name matches the regex provided to the filter
+   * and the one where it does not.
+   */
+  @Test
+  public void test() {
+    assertNotNull(filter);
+    assertInstanceOf(LoggerNameFilter.class, filter);
+
+
+    matchingLogger.info("This log message should be accepted by the filter.");
+    // The appender should have only received the log message from the matching logger.
+    assertEquals(1, appender.getMessages().size());
+    appender.clear();
+    nonMatchingLogger.info("This log message should not be accepted by the filter.");
+    assertTrue(appender.getMessages().isEmpty());
+  }
+
+}

--- a/src/test/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilterTest.java
+++ b/src/test/java/com/microsoft/pnp/logging/loganalytics/LoggerNameFilterTest.java
@@ -1,13 +1,17 @@
 package com.microsoft.pnp.logging.loganalytics;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @LoggerContextSource("log4j-loggernamefilter.xml")
@@ -18,11 +22,13 @@ public class LoggerNameFilterTest {
   private final Logger matchingLogger;
   private final Logger nonMatchingLogger;
 
+
   public LoggerNameFilterTest(final LoggerContext context, @Named("LIST") final ListAppender app) {
     this.appender = app;
     this.filter = (LoggerNameFilter)app.getFilter();
     this.matchingLogger = context.getLogger(getClass());
     this.nonMatchingLogger = context.getLogger("com.not.matching.logger");
+
   }
 
   /**
@@ -30,7 +36,7 @@ public class LoggerNameFilterTest {
    * and the one where it does not.
    */
   @Test
-  public void test() {
+  public void testFilteringByNameIsOperational() {
     assertNotNull(filter);
     assertInstanceOf(LoggerNameFilter.class, filter);
 
@@ -41,6 +47,30 @@ public class LoggerNameFilterTest {
     appender.clear();
     nonMatchingLogger.info("This log message should not be accepted by the filter.");
     assertTrue(appender.getMessages().isEmpty());
+  }
+
+
+  @Test
+  public void testInvalidRegexNoLog() {
+    // We start with the correct configuration
+    matchingLogger.info("This log message should be accepted by the filter.");
+    assertEquals(1, appender.getMessages().size());
+    appender.clear();
+    // And switch to a failing configuration
+    org.apache.logging.log4j.core.LoggerContext ctx =
+            (org.apache.logging.log4j.core.LoggerContext) LogManager.getContext(false);
+    URL confURL = this.getClass().getClassLoader().getResource("log4j-loggernamefilter-invalidregexp.xml");
+    try {
+      ctx.setConfigLocation(confURL.toURI());
+    } catch (Exception e) {
+      Assertions.fail(e.getMessage());
+    }
+    ctx.updateLoggers();
+
+    ctx.getLogger("foo").info("bar");
+    // Note the  IllegalArgumentException raised due to invalid regex is catched by Log4j,  but hidden unless  log4j.debug property is set.
+    matchingLogger.info("This log message should be accepted by the filter.");
+    assertEquals(0, appender.getMessages().size());
   }
 
 }

--- a/src/test/resources/log4j-loggernamefilter-invalidregexp.xml
+++ b/src/test/resources/log4j-loggernamefilter-invalidregexp.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF" name="LoggerNameFilterTest">
+    <Appenders>
+        <List name="LISTNOK">
+            <PatternLayout pattern="%-5p %d{dd-MMM-yyyy HH:mm:ss} %t %m%n"/>
+            <!-- let say we are only interested in logger names having iamsecret in the name-->
+            <LoggerNameFilter regex="(this is an invalid regex"/>
+        </List>
+
+    </Appenders>
+
+    <Loggers>
+        <Root level="TRACE">
+            <AppenderRef ref="LISTNOK"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/test/resources/log4j-loggernamefilter-noregexp.xml
+++ b/src/test/resources/log4j-loggernamefilter-noregexp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF" name="LoggerNameFilterTest">
+    <Appenders>
+        <List name="LIST">
+            <PatternLayout pattern="%-5p %d{dd-MMM-yyyy HH:mm:ss} %t %m%n"/>
+            <!-- let say we are only interested in logger names having iamsecret in the name-->
+            <LoggerNameFilter/>
+        </List>
+    </Appenders>
+
+    <Loggers>
+        <Root level="TRACE">
+            <AppenderRef ref="LIST"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/test/resources/log4j-loggernamefilter.xml
+++ b/src/test/resources/log4j-loggernamefilter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF" name="LoggerNameFilterTest">
+  <Appenders>
+    <List name="LIST">
+      <PatternLayout pattern="%-5p %d{dd-MMM-yyyy HH:mm:ss} %t %m%n"/>
+      <LoggerNameFilter regex="com\.microsoft\.pnp\.logging\.loganalytics.*"/>
+    </List>
+  </Appenders>
+
+  <Loggers>
+    <Root level="TRACE">
+      <AppenderRef ref="LIST"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
This pull-request aims at bringing back the complex filtering features on SparkLoggingEvent_CL, which were dropped when the l4jv2 branche was created.
This will effectively solve issue #215.

For logger_name_s-based filtering, this is done by implementing a custom Log4j Filter (com.microsoft.pnp.logging.loganalytics.LoggerNameFilter) which can then be used in the init_script and configured using the LA_SPARKLOGGINGEVENT_NAME_REGEX env variable, as in main branch.
For message-based filtering the already existing RegexFilter is used in the init_script and configured using the LA_SPARKLOGGINGEVENT_MESSAGE_REGEX env variable, as in main branch.